### PR TITLE
feat(newsletter): add wpsms_unsubscribe_success_message filter

### DIFF
--- a/src/Controller/PublicUnsubscribeAjax.php
+++ b/src/Controller/PublicUnsubscribeAjax.php
@@ -79,7 +79,26 @@ class PublicUnsubscribeAjax extends AjaxControllerAbstract
             }
         }
 
-        wp_send_json_success(esc_html__('You have successfully unsubscribed from the newsletter.', 'wp-sms'));
+        /**
+         * Filter the unsubscribe success message.
+         *
+         * Allows customizing the confirmation message shown after a successful
+         * unsubscribe, for example to show a different message per group.
+         *
+         * @since 7.2.6
+         *
+         * @param string    $message  The default success message.
+         * @param array|int $groupIds The group ID(s) the number was unsubscribed from (empty for all groups).
+         * @param string    $number   The unsubscribed mobile number.
+         */
+        $message = apply_filters(
+            'wpsms_unsubscribe_success_message',
+            esc_html__('You have successfully unsubscribed from the newsletter.', 'wp-sms'),
+            $groupIds,
+            $number
+        );
+
+        wp_send_json_success($message);
     }
 
 }


### PR DESCRIPTION
## Problem
The unsubscribe confirmation message (`PublicUnsubscribeAjax.php`) is a hardcoded string with no setting or filter, so site owners cannot customize it - e.g. to show a different message depending on which group the user unsubscribed from. Requested in helpdesk #16331.

## Change
Add a `wpsms_unsubscribe_success_message` filter at the success point. The group ID(s) the number was unsubscribed from (`$groupIds`) and the `$number` are already in scope, so they are passed to the filter:

```php
$message = apply_filters(
    'wpsms_unsubscribe_success_message',
    esc_html__('You have successfully unsubscribed from the newsletter.', 'wp-sms'),
    $groupIds,
    $number
);
wp_send_json_success($message);
```

Consistent with the existing `wpsms_unsubscribe_query_string` / `wpsms_unsubscribe_csrf_enabled` filters.

## Example usage (per-group message)
```php
add_filter('wpsms_unsubscribe_success_message', function ($message, $groupIds, $number) {
    if (in_array(12, (array) $groupIds)) return 'You have successfully unsubscribed from the Last Minute Care Service!';
    if (in_array(15, (array) $groupIds)) return 'You have successfully unsubscribed from the Verified Care Provider Service!';
    return $message;
}, 10, 3);
```

## Compatibility
Backward compatible - the default message is unchanged when no filter is registered. `php -l` clean. A dev build (7.2.5.1) was shared with the reporter for testing.

Ref: helpdesk #16331