### PR TITLE
Add WSMS v8 Early Access callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 # WSMS - WordPress SMS Plugin
 
+> 🚀 **WSMS v8 Early Access is open** — a major rewrite, and we'd love your feedback. Developers and active users welcome. **[Want in? Comment here →](https://github.com/wp-sms/wp-sms/discussions/482)**
+
 SMS & MMS Notifications, 2FA, OTP, and Integrations with E-Commerce and Form Builders. Send messages through **200+ gateways** including Twilio, Plivo, Clickatell, BulkSMS, Infobip, Vonage (Nexmo), Messagebird, ClickSend and more. [See all gateways](https://wsms.io/gateways/)
 
 <p align="center">


### PR DESCRIPTION
Adds a one-line callout near the top of the README linking to the v8 Early Access sign-up discussion (#482). Easy to revert when Early Access ends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an announcement banner for WSMS v8 Early Access at the top of the documentation with a feedback link for user input on the upcoming version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->