### PR TITLE
Add file output mode to the test (mock) gateway

### DIFF
--- a/includes/gateways/class-wpsms-gateway-test.php
+++ b/includes/gateways/class-wpsms-gateway-test.php
@@ -4,6 +4,19 @@ namespace WP_SMS\Gateway;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
+/**
+ * Test / mock gateway.
+ *
+ * Does not talk to any real provider. Instead it can either fabricate a
+ * randomized success response (JSON mode) or append each message to a local
+ * log file (File mode). Useful for local development, demos, offline work and
+ * CI, where you want to exercise the SMS pipeline without spending real credit.
+ *
+ * The output is chosen with the "Output Type" setting:
+ *  - json (default) — build a fake response array and log it to the Outbox.
+ *                     This is the historical behaviour of this gateway.
+ *  - file          — append one line per message to a configurable log file.
+ */
 class test extends \WP_SMS\Gateway
 {
     private $wsdl_link = '';
@@ -13,6 +26,22 @@ class test extends \WP_SMS\Gateway
     public $flash = "enable";
     public $isflash = false;
     public $options;
+
+    /**
+     * Output mode: 'json' (fake response) or 'file' (write to log file).
+     * Populated from the gateway settings by Gateway::initial().
+     *
+     * @var string
+     */
+    public $output_type = 'json';
+
+    /**
+     * Absolute path of the file messages are written to in file mode.
+     * Populated from the gateway settings by Gateway::initial().
+     *
+     * @var string
+     */
+    public $log_file = '';
 
     public function __construct()
     {
@@ -24,10 +53,28 @@ class test extends \WP_SMS\Gateway
         $this->supportMedia    = true;
         $this->supportIncoming = true;
         $this->gatewayFields   = [
-            'from' => [
+            'from'        => [
                 'id'   => 'gateway_sender_id',
                 'name' => 'Sender ID',
                 'desc' => 'Enter your sender ID',
+            ],
+            'output_type' => [
+                'id'      => 'gateway_output_type',
+                'name'    => esc_html__('Output Type', 'wp-sms'),
+                'desc'    => esc_html__('How "sent" messages are handled. JSON fabricates a fake response (no send). File appends each message to a log file.', 'wp-sms'),
+                'type'    => 'select',
+                'options' => [
+                    'json' => 'JSON (fake response)',
+                    'file' => 'File (write to log)',
+                ],
+            ],
+            'log_file'    => [
+                'id'        => 'gateway_test_log_file',
+                'name'      => esc_html__('Log File Path', 'wp-sms'),
+                'desc'      => esc_html__('Absolute path where messages are written in File mode. Leave empty to use wp-content/uploads/wp-sms-mock.log.', 'wp-sms'),
+                'type'      => 'text',
+                // Only show this field when Output Type is set to "file".
+                'className' => 'js-wpsms-show_if_gateway_output_type_equal_file',
             ],
         ];
     }
@@ -62,37 +109,17 @@ class test extends \WP_SMS\Gateway
         $this->msg = apply_filters('wp_sms_msg', $this->msg);
 
         try {
-            $params = [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-                'body'    => wp_json_encode([
-                    'action'    => 'send-sms',
-                    'sender_id' => $this->from,
-                    'recipient' => implode(',', $this->to),
-                    'message'   => $this->msg
-                ])
-            ];
+            // Anything other than an explicit "file" falls back to json, so an
+            // empty/unset option keeps the historical behaviour.
+            $response = ($this->output_type === 'file')
+                ? $this->writeToFile()
+                : $this->fakeResponse();
 
-            // generate a randomized fake response
-            $response = [
-                'success'    => true,
-                'status'     => 'sent',
-                'message_id' => uniqid('sms_'),
-                'from'       => $this->from,
-                'to'         => $this->to,
-                'recipients' => is_array($this->to) ? count($this->to) : 1,
-                'message'    => $this->msg,
-                'flash'      => $this->isflash,
-                'media'      => $this->media ?: null,
-                'cost'       => sprintf('%.2f USD', wp_rand(5, 500) / 100),
-                'sent_at'    => current_time('mysql'),
-                'error'      => null,
-                'raw'        => [
-                    'params'   => $params,
-                    'debug_id' => wp_rand(100000, 999999),
-                ],
-            ];
+            if (is_wp_error($response)) {
+                $this->log($this->from, $this->msg, $this->to, $response->get_error_message(), 'error', $this->media);
+
+                return $response;
+            }
 
             //log the result
             $this->log($this->from, $this->msg, $this->to, $response, 'success', $this->media);
@@ -113,6 +140,100 @@ class test extends \WP_SMS\Gateway
 
             return new \WP_Error('send-sms', $e->getMessage());
         }
+    }
+
+    /**
+     * JSON mode: build a randomized fake response (no real send).
+     *
+     * @return array
+     */
+    private function fakeResponse()
+    {
+        $params = [
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body'    => wp_json_encode([
+                'action'    => 'send-sms',
+                'sender_id' => $this->from,
+                'recipient' => implode(',', $this->to),
+                'message'   => $this->msg
+            ])
+        ];
+
+        // generate a randomized fake response
+        return [
+            'success'    => true,
+            'status'     => 'sent',
+            'message_id' => uniqid('sms_'),
+            'from'       => $this->from,
+            'to'         => $this->to,
+            'recipients' => is_array($this->to) ? count($this->to) : 1,
+            'message'    => $this->msg,
+            'flash'      => $this->isflash,
+            'media'      => $this->media ?: null,
+            'cost'       => sprintf('%.2f USD', wp_rand(5, 500) / 100),
+            'sent_at'    => current_time('mysql'),
+            'error'      => null,
+            'raw'        => [
+                'params'   => $params,
+                'debug_id' => wp_rand(100000, 999999),
+            ],
+        ];
+    }
+
+    /**
+     * File mode: append one line per message to the log file.
+     *
+     * @return string|\WP_Error Human-readable result string, or WP_Error on write failure.
+     */
+    private function writeToFile()
+    {
+        $recipients = is_array($this->to) ? implode(', ', $this->to) : $this->to;
+
+        $line = sprintf(
+            "[%s] FROM: %s | TO: %s | MSG: %s%s",
+            current_time('mysql'),
+            $this->from !== '' ? $this->from : '(none)',
+            $recipients,
+            str_replace(["\r", "\n"], ' ', (string) $this->msg),
+            PHP_EOL
+        );
+
+        $file    = $this->getLogFilePath();
+        $written = @file_put_contents($file, $line, FILE_APPEND | LOCK_EX);
+
+        if ($written === false) {
+            // translators: %s: log file path
+            return new \WP_Error('send-sms', sprintf(esc_html__('Test gateway: could not write to log file: %s', 'wp-sms'), $file));
+        }
+
+        // translators: %s: log file path
+        return sprintf(esc_html__('Message written to %s', 'wp-sms'), $file);
+    }
+
+    /**
+     * Resolve the target log file, falling back to wp-content/uploads, and
+     * make sure its parent directory exists.
+     *
+     * @return string
+     */
+    private function getLogFilePath()
+    {
+        $path = trim((string) $this->log_file);
+
+        if ($path === '') {
+            $uploads = wp_upload_dir();
+            $path    = trailingslashit($uploads['basedir']) . 'wp-sms-mock.log';
+        }
+
+        // e.g. uploads/ may not exist before any media has been added.
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            wp_mkdir_p($dir);
+        }
+
+        return $path;
     }
 
     public function GetCredit()


### PR DESCRIPTION
## What

Adds a **file output mode** to the built-in `test` (mock) gateway, so "sent" messages can be written to a local log file instead of only being fabricated in memory.

A new **Output Type** setting selects the behaviour:

- **JSON** *(default)* — the gateway's existing behaviour: build a randomized fake response and log it to the Outbox.
- **File** — append one line per message to a log file, defaulting to `wp-content/uploads/wp-sms-mock.log` (a custom path can be set, and its parent directory is created if missing).

Closes #487.

## Why

The `test` gateway is great for exercising the send pipeline without a real provider, but the message only lands in the DB Outbox. For local development, demos, offline work and CI it's much handier to have a plain-text artifact you can `tail -f` or grep:

```
[2026-07-08 12:19:07] FROM: Store | TO: +15551234567, +15559998888 | MSG: hi file
```

Previously the only way to capture messages to a file was to stand up an HTTP endpoint and point the `custom` gateway at it.

## Backward compatibility

The Output Type defaults to `json`, and any empty/unset value falls back to `json`, so existing installs using the `test` gateway behave **exactly** as before. The file mode is purely additive and opt-in — no breaking change.

## Changes

- `includes/gateways/class-wpsms-gateway-test.php`
  - New `output_type` (`json` | `file`) and `log_file` settings fields. The log-file field is only shown when File mode is selected (`js-wpsms-show_if_gateway_output_type_equal_file`).
  - `SendSMS()` routes to `fakeResponse()` (unchanged JSON path) or the new `writeToFile()`.
  - `writeToFile()` appends a formatted line and returns a result string, or a `WP_Error` on write failure (logged as an error, like real gateways).
  - JSON response shape and `GetCredit()` are unchanged.

## Testing

Verified on a local WordPress (WP_DEBUG on, so the gateway is listed) against both modes:

- **JSON mode** — `SendSMS()` returns the same randomized response array (`message_id`, `cost`, …) as before.
- **File mode** — the message is appended to the default uploads path (directory auto-created), and the Outbox entry is still written.

`php -l` passes on the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The test SMS gateway now lets you choose how test messages are returned: a JSON-style fake response or a file-based log output.
  * Added a log file path setting that appears when file output is selected.
  * Improved feedback when file logging fails, while keeping successful sends working as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->