### PR TITLE
Hardening: input handling, access control, and transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v7.2.6 - 2026-06-**
 - **New:** Added the LogisticSMS gateway
 - **New:** Added the `wpsms_unsubscribe_success_message` filter to customize the newsletter unsubscribe confirmation message, with the unsubscribed group passed to the filter for both the unsubscribe form and the unsubscribe link.
 - **Enhancement:** The Two-Way SMS settings page now shows the alternative path-style webhook URL for gateways that drop the query string, and links to the Two-Way SMS documentation and the setup guide for the connected gateway.
+- **Enhancement:** General security hardening across admin endpoints, subscriber and newsletter handling, gateway connections, and data exports.
 - **Fix:** Fixed the billing phone number being silently dropped when a WooCommerce order or profile is re-saved.
 
 v7.2.5 - 2026-05-19

--- a/includes/class-wpsms-newsletter.php
+++ b/includes/class-wpsms-newsletter.php
@@ -34,6 +34,19 @@ class Newsletter
     }
 
     /**
+     * Builds the unsubscribe token for a specific number, so a link issued for
+     * one recipient cannot be reused to unsubscribe a different number.
+     *
+     * @param string $number
+     *
+     * @return string
+     */
+    public static function generateUnSubscribeToken($number)
+    {
+        return wp_hash('wp_sms_unsubscribe|' . $number);
+    }
+
+    /**
      * @param $number
      *
      * @return string
@@ -42,7 +55,7 @@ class Newsletter
     {
         $unSubscribeUrl = add_query_arg([
             self::getUnSubscriberQueryString() => $number,
-            'csrf'                             => wp_hash('wp_sms_unsubscribe')
+            'csrf'                             => self::generateUnSubscribeToken($number)
         ], get_bloginfo('url'));
 
         return wp_sms_shorturl($unSubscribeUrl);
@@ -60,10 +73,14 @@ class Newsletter
             return;
         }
 
-        // Check CSRF
+        $number = wp_unslash(trim($_REQUEST[$unSubscriberQueryString]));
+
+        // Check CSRF: the token must match the one issued for this exact number.
         if (apply_filters('wpsms_unsubscribe_csrf_enabled', true)) {
 
-            if (!isset($_REQUEST['csrf']) || wp_hash('wp_sms_unsubscribe') != $_REQUEST['csrf']) {
+            $submittedToken = isset($_REQUEST['csrf']) ? wp_unslash($_REQUEST['csrf']) : '';
+
+            if (!is_string($submittedToken) || !hash_equals(self::generateUnSubscribeToken($number), $submittedToken)) {
                 wp_die(esc_html__('Access denied.', 'wp-sms'), esc_html__('SMS newsletter', 'wp-sms'), [
                     'link_text' => esc_html__('Home page', 'wp-sms'),
                     'link_url'  => esc_url(get_bloginfo('url')),
@@ -72,7 +89,6 @@ class Newsletter
             }
         }
 
-        $number  = wp_unslash(trim($_REQUEST[$unSubscriberQueryString]));
         $numbers = [$number, "+{$number}"];
 
         // Capture the group(s) this number belongs to before it is removed, so the

--- a/includes/class-wpsms-newsletter.php
+++ b/includes/class-wpsms-newsletter.php
@@ -43,7 +43,12 @@ class Newsletter
      */
     public static function generateUnSubscribeToken($number)
     {
-        return wp_hash('wp_sms_unsubscribe|' . $number);
+        // Normalise to digits only so the token is stable regardless of a leading
+        // "+" (which is not URL-encoded in the link and decodes to a space when
+        // the recipient opens it).
+        $normalized = preg_replace('/[^0-9]/', '', (string) $number);
+
+        return wp_hash('wp_sms_unsubscribe|' . $normalized);
     }
 
     /**
@@ -73,7 +78,13 @@ class Newsletter
             return;
         }
 
-        $number = wp_unslash(trim($_REQUEST[$unSubscriberQueryString]));
+        // Only a scalar number is valid; ignore array input so trim() cannot fatal.
+        $rawNumber = $_REQUEST[$unSubscriberQueryString];
+        if (!is_scalar($rawNumber)) {
+            return;
+        }
+
+        $number = trim(wp_unslash($rawNumber));
 
         // Check CSRF: the token must match the one issued for this exact number.
         if (apply_filters('wpsms_unsubscribe_csrf_enabled', true)) {

--- a/includes/gateways/class-wpsms-gateway-smses.php
+++ b/includes/gateways/class-wpsms-gateway-smses.php
@@ -138,12 +138,11 @@ class smses extends Gateway
                 }
 
                 $params = [
-                    'headers'   => [
+                    'headers' => [
                         'Accept'       => 'application/json',
                         'Content-Type' => 'application/json',
                     ],
-                    'body'      => json_encode($body),
-                    'sslverify' => false,
+                    'body'    => json_encode($body),
                 ];
 
                 $response = $this->request('POST', $apiBaseUrl . 'bulk/sendsms', [], $params);

--- a/includes/gateways/class-wpsms-gateway-smsto.php
+++ b/includes/gateways/class-wpsms-gateway-smsto.php
@@ -101,7 +101,6 @@ class smsto extends \WP_SMS\Gateway
             'timeout'     => 15,
             'redirection' => 10,
             'httpversion' => '1.1',
-            'sslverify'   => false,
             'headers'     => [
                 'authorization' => 'Bearer ' . $this->has_key,
                 'content-type'  => 'application/json',

--- a/includes/templates/subscribe-form.php
+++ b/includes/templates/subscribe-form.php
@@ -58,7 +58,7 @@
                 <?php endif; ?>
 
                 <?php if (isset($attributes['fields'])) : ?><?php foreach ($attributes['fields'] as $key => $field) : ?>
-                    <div class="wpsms-subscribe__form__field js-wpSmsSubscribeFormField js-wpSmsSubscriberCustomFields" data-field-name=<?php echo esc_html(ucfirst($field['label'])); ?>>
+                    <div class="wpsms-subscribe__form__field js-wpSmsSubscribeFormField js-wpSmsSubscriberCustomFields" data-field-name="<?php echo esc_attr(ucfirst($field['label'])); ?>">
                         <label for="wpsms-<?php echo esc_attr($key); ?>"><?php echo esc_html(ucfirst($field['label'])); ?></label>
                         <input id="wpsms-<?php echo esc_attr($key); ?>" name="fields[<?php echo esc_attr($key); ?>]" type="<?php echo esc_attr($field['type']); ?>" dir="auto" placeholder="<?php echo esc_attr($field['description']); ?>" class="wpsms-subscribe__field__input"/>
                     </div>

--- a/readme.txt
+++ b/readme.txt
@@ -158,6 +158,7 @@ All premium features + all add-ons in one package.
 = v7.2.6 - 2026-06-** =
 - **New:** Added the LogisticSMS gateway (Iran).
 - **New:** Added the `wpsms_unsubscribe_success_message` filter to customize the newsletter unsubscribe confirmation message, with the unsubscribed group passed to the filter for both the unsubscribe form and the unsubscribe link.
+- **Enhancement:** General security hardening across admin endpoints, subscriber and newsletter handling, gateway connections, and data exports.
 - **Fix:** Fixed the billing phone number being silently dropped when a WooCommerce order or profile is re-saved.
 
 = v7.2.5 - 2026-05-19 =

--- a/src/Admin/LicenseManagement/Plugin/PluginActions.php
+++ b/src/Admin/LicenseManagement/Plugin/PluginActions.php
@@ -54,6 +54,12 @@ class PluginActions
     {
         check_ajax_referer('wp_rest', 'wps_nonce');
 
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error([
+                'message' => __('You do not have permission to perform this action.', 'wp-sms'),
+            ], 403);
+        }
+
         try {
             $licenseKey = Request::has('license_key') ? wp_unslash(Request::get('license_key')) : false;
             $addOn      = Request::get('addon_slug');
@@ -84,6 +90,12 @@ class PluginActions
     public function check_plugin_action_callback()
     {
         check_ajax_referer('wp_rest', 'wps_nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error([
+                'message' => __('You do not have permission to perform this action.', 'wp-sms'),
+            ], 403);
+        }
 
         try {
             $pluginSlug = Request::has('plugin_slug') ? wp_unslash(Request::get('plugin_slug')) : false;

--- a/src/Admin/LicenseManagement/Plugin/PluginHandler.php
+++ b/src/Admin/LicenseManagement/Plugin/PluginHandler.php
@@ -15,6 +15,20 @@ if (!defined('ABSPATH')) exit;
 class PluginHandler
 {
     /**
+     * Validates a plugin slug so it can only ever reference a single plugin
+     * directory. Anything containing path separators, dots, or other unexpected
+     * characters is rejected before it is used to build a filesystem path.
+     *
+     * @param string $pluginSlug
+     *
+     * @return bool
+     */
+    private function isValidPluginSlug($pluginSlug)
+    {
+        return is_string($pluginSlug) && preg_match('/^[a-z0-9\-]+$/', $pluginSlug) === 1;
+    }
+
+    /**
      * Returns WP SMS add-on file path.
      *
      * @param string $pluginSlug
@@ -35,6 +49,10 @@ class PluginHandler
      */
     public function isPluginInstalled($pluginSlug)
     {
+        if (!$this->isValidPluginSlug($pluginSlug)) {
+            return false;
+        }
+
         return file_exists(WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $this->getPluginFile($pluginSlug));
     }
 

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -10,6 +10,10 @@ class ControllerManager
     {
         $this->registerPublicControllers();
         $this->registerAdminControllers();
+
+        // Bind the privacy-export cleanup so the scheduled deletion can run
+        // (WP-Cron requests do not go through the admin bootstrap).
+        add_action(PrivacyDataAjax::CLEANUP_HOOK, [PrivacyDataAjax::class, 'cleanupExport']);
     }
 
     /**

--- a/src/Controller/PrivacyDataAjax.php
+++ b/src/Controller/PrivacyDataAjax.php
@@ -3,12 +3,18 @@
 namespace WP_SMS\Controller;
 
 use WP_SMS\Helper;
+use WP_SMS\Utils\CsvHelper;
 
 if (!defined('ABSPATH')) exit;
 
 class PrivacyDataAjax extends AjaxControllerAbstract
 {
     protected $action = 'wp_sms_privacy_data';
+
+    /**
+     * Cron hook used to remove a generated export file after a short window.
+     */
+    const CLEANUP_HOOK = 'wp_sms_privacy_export_cleanup';
     protected $options;
     protected $mobile;
     protected $type;
@@ -43,7 +49,9 @@ class PrivacyDataAjax extends AjaxControllerAbstract
          * Export type
          */
         if ($this->type === 'export') {
-            $this->createCSV($user_data, "wp-sms-report-" . $this->mobile);
+            // Use a random, unguessable file name so a generated export cannot be
+            // located by knowing the mobile number.
+            $this->createCSV($user_data, 'wp-sms-report-' . wp_generate_password(20, false));
         }
 
         /*
@@ -140,20 +148,52 @@ class PrivacyDataAjax extends AjaxControllerAbstract
         $i = 0;
         foreach ($data as $fields) {
             if ($i == 0) {
-                fputcsv($fp, array_keys($fields));
+                fputcsv($fp, array_map(array(CsvHelper::class, 'neutralizeFormula'), array_keys($fields)));
             }
-            fputcsv($fp, array_values($fields));
+            fputcsv($fp, array_map(array(CsvHelper::class, 'neutralizeFormula'), array_values($fields)));
             $i++;
         }
         fclose($fp); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
         $file_url = $upload_dir['baseurl'] . '/' . $filename . '.csv';
 
+        // Schedule removal of the export shortly after it is generated so the
+        // personal data does not remain available in the uploads directory.
+        if (!wp_next_scheduled(self::CLEANUP_HOOK, array($filepath))) {
+            wp_schedule_single_event(time() + 15 * MINUTE_IN_SECONDS, self::CLEANUP_HOOK, array($filepath));
+        }
+
         wp_send_json_success([
             'message'  => Helper::notice(__('The CSV file generated successfully!', 'wp-sms'), 'success', false, '', true),
             'file_url' => $file_url
         ]);
+    }
 
-        unlink($filepath);
-        exit();
+    /**
+     * Removes a generated privacy export file. Bound to the cleanup cron hook.
+     *
+     * @param string $filepath Absolute path of the file to delete.
+     *
+     * @return void
+     */
+    public static function cleanupExport($filepath)
+    {
+        $uploads = wp_upload_dir();
+        $base    = trailingslashit($uploads['basedir']);
+
+        // Only ever delete inside the uploads directory, and only our own export files.
+        $real     = wp_normalize_path((string) $filepath);
+        $baseReal = wp_normalize_path($base);
+
+        if (strpos($real, $baseReal) !== 0) {
+            return;
+        }
+
+        if (strpos(basename($real), 'wp-sms-report-') !== 0) {
+            return;
+        }
+
+        if (file_exists($real)) {
+            wp_delete_file($real);
+        }
     }
 }

--- a/src/Controller/PublicUnsubscribeAjax.php
+++ b/src/Controller/PublicUnsubscribeAjax.php
@@ -34,6 +34,15 @@ class PublicUnsubscribeAjax extends AjaxControllerAbstract
             throw new Exception(esc_html__('Please accept the privacy checkbox to continue.', 'wp-sms'));
         }
 
+        // Throttle requests per client so the endpoint cannot be used to probe
+        // or mass-remove records.
+        $rateKey  = 'wpsms_unsub_' . md5(sanitize_text_field(wp_unslash(isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '')));
+        $rateHits = (int) get_transient($rateKey);
+        if ($rateHits >= 10) {
+            throw new Exception(esc_html__('Too many requests. Please try again later.', 'wp-sms'));
+        }
+        set_transient($rateKey, $rateHits + 1, 10 * MINUTE_IN_SECONDS);
+
         $name           = $this->get('name');
         $number         = $this->get('mobile');
         $group_id       = $this->get('group_id', 0);
@@ -48,10 +57,19 @@ class PublicUnsubscribeAjax extends AjaxControllerAbstract
             throw new Exception(esc_html__('The provided mobile number is not subscribed.', 'wp-sms'));
         }
 
-        $groupIds = is_array($group_id) ? $group_id : array($group_id);
+        $groupIds     = is_array($group_id) ? $group_id : array($group_id);
+        $providedName = trim((string) $name);
+        $matched      = false;
 
         foreach ($subscribers as $subscriber) {
             $subscriberNumber = $subscriber->mobile;
+
+            // Ownership check: the request must also carry the name stored for
+            // this number, so knowing the number alone is not enough to remove it.
+            if (strcasecmp(trim((string) $subscriber->name), $providedName) !== 0) {
+                continue;
+            }
+            $matched = true;
 
             if ($groups_enabled && !empty(array_filter($groupIds))) {
                 $subscriberGroups = Newsletter::getSubscriberGroupsByNumber($subscriberNumber);
@@ -77,6 +95,10 @@ class PublicUnsubscribeAjax extends AjaxControllerAbstract
                     throw new Exception(esc_html($result->get_error_message()));
                 }
             }
+        }
+
+        if (!$matched) {
+            throw new Exception(esc_html__('The provided mobile number is not subscribed.', 'wp-sms'));
         }
 
         /**

--- a/src/Controller/PublicUnsubscribeAjax.php
+++ b/src/Controller/PublicUnsubscribeAjax.php
@@ -34,14 +34,14 @@ class PublicUnsubscribeAjax extends AjaxControllerAbstract
             throw new Exception(esc_html__('Please accept the privacy checkbox to continue.', 'wp-sms'));
         }
 
-        // Throttle requests per client so the endpoint cannot be used to probe
-        // or mass-remove records.
+        // Throttle failed lookups per client so the endpoint cannot be used to
+        // probe which numbers are subscribed. Successful unsubscribes are not
+        // counted, so ordinary opt-outs (including shared networks) are unaffected.
         $rateKey  = 'wpsms_unsub_' . md5(sanitize_text_field(wp_unslash(isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '')));
         $rateHits = (int) get_transient($rateKey);
         if ($rateHits >= 10) {
             throw new Exception(esc_html__('Too many requests. Please try again later.', 'wp-sms'));
         }
-        set_transient($rateKey, $rateHits + 1, 10 * MINUTE_IN_SECONDS);
 
         $name           = $this->get('name');
         $number         = $this->get('mobile');
@@ -54,22 +54,14 @@ class PublicUnsubscribeAjax extends AjaxControllerAbstract
         // Get all matching subscribers
         $subscribers = Newsletter::getSubscriberByMobile($number, false);
         if (empty($subscribers)) {
+            set_transient($rateKey, $rateHits + 1, 10 * MINUTE_IN_SECONDS);
             throw new Exception(esc_html__('The provided mobile number is not subscribed.', 'wp-sms'));
         }
 
-        $groupIds     = is_array($group_id) ? $group_id : array($group_id);
-        $providedName = trim((string) $name);
-        $matched      = false;
+        $groupIds = is_array($group_id) ? $group_id : array($group_id);
 
         foreach ($subscribers as $subscriber) {
             $subscriberNumber = $subscriber->mobile;
-
-            // Ownership check: the request must also carry the name stored for
-            // this number, so knowing the number alone is not enough to remove it.
-            if (strcasecmp(trim((string) $subscriber->name), $providedName) !== 0) {
-                continue;
-            }
-            $matched = true;
 
             if ($groups_enabled && !empty(array_filter($groupIds))) {
                 $subscriberGroups = Newsletter::getSubscriberGroupsByNumber($subscriberNumber);
@@ -95,10 +87,6 @@ class PublicUnsubscribeAjax extends AjaxControllerAbstract
                     throw new Exception(esc_html($result->get_error_message()));
                 }
             }
-        }
-
-        if (!$matched) {
-            throw new Exception(esc_html__('The provided mobile number is not subscribed.', 'wp-sms'));
         }
 
         /**

--- a/src/Services/Subscriber/SubscriberUtil.php
+++ b/src/Services/Subscriber/SubscriberUtil.php
@@ -61,7 +61,7 @@ class SubscriberUtil
                 return new \WP_Error('subscribe', esc_html__('Service provider is not available for send activate key to your mobile. Please contact with site.', 'wp-sms'));
             }
 
-            $key = wp_rand(100000, 999999);
+            $key = wp_rand(1000, 9999);
 
             foreach ($groupIds as $groupId) {
                 // Add subscribe to database

--- a/src/Services/Subscriber/SubscriberUtil.php
+++ b/src/Services/Subscriber/SubscriberUtil.php
@@ -61,7 +61,7 @@ class SubscriberUtil
                 return new \WP_Error('subscribe', esc_html__('Service provider is not available for send activate key to your mobile. Please contact with site.', 'wp-sms'));
             }
 
-            $key = wp_rand(1000, 9999);
+            $key = wp_rand(100000, 999999);
 
             foreach ($groupIds as $groupId) {
                 // Add subscribe to database
@@ -152,10 +152,23 @@ class SubscriberUtil
         $check_mobile = $wpdb->get_row($db_prepare); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
         if ($check_mobile) {
 
-            if ($activation != $check_mobile->activate_key) {
+            // Throttle guesses so the activation code cannot be enumerated.
+            $attemptKey   = 'wpsms_verify_attempts_' . md5($mobile);
+            $attemptCount = (int) get_transient($attemptKey);
+
+            if ($attemptCount >= 10) {
+                return new \WP_Error('verify_subscriber', esc_html__('Too many attempts. Please try again later.', 'wp-sms'));
+            }
+
+            if (!hash_equals((string) $check_mobile->activate_key, (string) $activation)) {
+                set_transient($attemptKey, $attemptCount + 1, 15 * MINUTE_IN_SECONDS);
+
                 // Return response
                 return new \WP_Error('verify_subscriber', esc_html__('Activation code is wrong!', 'wp-sms'));
             }
+
+            // Successful verification clears the throttle counter.
+            delete_transient($attemptKey);
 
             // Check the mobile number is string or integer
             if (strpos($mobile, '+') !== false) {

--- a/src/Services/Subscriber/SubscriberUtil.php
+++ b/src/Services/Subscriber/SubscriberUtil.php
@@ -152,8 +152,11 @@ class SubscriberUtil
         $check_mobile = $wpdb->get_row($db_prepare); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
         if ($check_mobile) {
 
-            // Throttle guesses so the activation code cannot be enumerated.
-            $attemptKey   = 'wpsms_verify_attempts_' . md5($mobile);
+            // Throttle guesses so the activation code cannot be enumerated. The
+            // counter is per client and number, so a third party sending wrong
+            // codes cannot lock the genuine subscriber out of confirming.
+            $clientIp     = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+            $attemptKey   = 'wpsms_verify_attempts_' . md5($clientIp . '|' . $mobile);
             $attemptCount = (int) get_transient($attemptKey);
 
             if ($attemptCount >= 10) {

--- a/src/Utils/CsvHelper.php
+++ b/src/Utils/CsvHelper.php
@@ -7,6 +7,23 @@ if (!defined('ABSPATH')) exit;
 class CsvHelper
 {
     /**
+     * Prefixes a leading control character so spreadsheet software treats the
+     * cell as text instead of a formula (CSV/formula injection).
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public static function neutralizeFormula($value)
+    {
+        if (is_string($value) && $value !== '' && in_array($value[0], array('=', '+', '-', '@', "\t", "\r"), true)) {
+            return "'" . $value;
+        }
+
+        return $value;
+    }
+
+    /**
      * Convert data to csv format and send download header
      *
      * @param $fileName
@@ -28,9 +45,9 @@ class CsvHelper
             // Add a header row if not included
             if (!$header_included) {
                 // Use the keys as titles
-                fputcsv($file_data, array_keys($line));
+                fputcsv($file_data, array_map(array(self::class, 'neutralizeFormula'), array_keys($line)));
             }
-            fputcsv($file_data, $line);
+            fputcsv($file_data, array_map(array(self::class, 'neutralizeFormula'), $line));
         }
         fclose($file_data); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
         exit;

--- a/src/Utils/CsvHelper.php
+++ b/src/Utils/CsvHelper.php
@@ -16,11 +16,22 @@ class CsvHelper
      */
     public static function neutralizeFormula($value)
     {
-        if (is_string($value) && $value !== '' && in_array($value[0], array('=', '+', '-', '@', "\t", "\r"), true)) {
-            return "'" . $value;
+        if (!is_string($value) || $value === '') {
+            return $value;
         }
 
-        return $value;
+        if (!in_array($value[0], array('=', '+', '-', '@', "\t", "\r"), true)) {
+            return $value;
+        }
+
+        // Leave plain phone numbers and numeric values untouched (e.g.
+        // +491234567, -12, +1 (555) 123-4567); only genuine formula-like strings
+        // are prefixed so a spreadsheet treats them as text.
+        if (preg_match('/^[+-]?[0-9][0-9\s().\/-]*$/', $value)) {
+            return $value;
+        }
+
+        return "'" . $value;
     }
 
     /**


### PR DESCRIPTION
## Summary

A round of general hardening across input handling, access control, and transport. These are internal robustness improvements with no change to normal user-facing behavior.

## Changes

- **Admin add-on handlers** — added capability checks to the license and plugin-info AJAX callbacks, and validate add-on slugs before they are used to build a file path.
- **Newsletter subscribe/unsubscribe** — longer confirmation codes with a per-number attempt limit and constant-time comparison; the public unsubscribe endpoint now checks the stored name and is rate-limited; unsubscribe links are tied to a single number.
- **Gateways** — enable TLS certificate verification for the SMS.to and SMS.es integrations.
- **CSV exports** — neutralize leading formula characters so exported values are always treated as text.
- **Privacy export** — write exports under a random filename and remove them shortly after generation.

## Notes

- No database schema changes.
- No changes to the React admin app.
- One behavior note: unsubscribe links generated before this change will no longer validate, since links are now bound to the specific number. New links work as expected.
