### PR TITLE
Fix Forminator field-recipient notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ v7.2.6 - 2026-06-**
 - **New:** Added the `wpsms_unsubscribe_success_message` filter to customize the newsletter unsubscribe confirmation message, with the unsubscribed group passed to the filter for both the unsubscribe form and the unsubscribe link.
 - **Enhancement:** The Two-Way SMS settings page now shows the alternative path-style webhook URL for gateways that drop the query string, and links to the Two-Way SMS documentation and the setup guide for the connected gateway.
 - **Enhancement:** General security hardening across admin endpoints, subscriber and newsletter handling, gateway connections, and data exports.
+- **Fix:** Fixed Forminator notifications configured to send SMS to a submitted phone field.
 - **Fix:** Fixed the billing phone number being silently dropped when a WooCommerce order or profile is re-saved.
 
 v7.2.5 - 2026-05-19

--- a/src/Services/Forminator/Forminator.php
+++ b/src/Services/Forminator/Forminator.php
@@ -3,6 +3,7 @@
 namespace WP_SMS\Services\Forminator;
 
 use Forminator_API;
+use WP_SMS\Components\Logger;
 use WP_SMS\Notification\NotificationFactory;
 use WP_SMS\Option;
 
@@ -41,19 +42,34 @@ class Forminator
         if (isset($sms_options['forminator_notify_enable_field_form_' . $form]) &&
             isset($sms_options['forminator_notify_message_field_form_' . $form])
         ) {
+            $receiverField = $sms_options['forminator_notify_receiver_field_form_' . $form] ?? '';
 
-            if (isset($this->data[$sms_options['forminator_notify_receiver_field_form_' . $form]])) {
+            if ($receiverField && isset($this->data[$receiverField])) {
                 $forminatorNotification->send(
                     $sms_options['forminator_notify_message_field_form_' . $form],
-                    $this->data[$sms_options['forminator_notify_receiver_field_form_' . $form]]
+                    $this->data[$receiverField]
                 );
+            } else {
+                Logger::log(sprintf('Forminator receiver field "%s" was not found for form %d.', $receiverField, $form), 'warning');
             }
         }
     }
 
     private function set_data()
     {
-        foreach (wp_sms_sanitize_array($_POST) as $index => $key) {
+        $submittedData = $_POST;
+
+        if (class_exists('Forminator_CForm_Front_Action') &&
+            property_exists('Forminator_CForm_Front_Action', 'prepared_data') &&
+            !empty(\Forminator_CForm_Front_Action::$prepared_data) &&
+            is_array(\Forminator_CForm_Front_Action::$prepared_data)
+        ) {
+            $submittedData = \Forminator_CForm_Front_Action::$prepared_data;
+        }
+
+        $this->data = [];
+
+        foreach (wp_sms_sanitize_array($submittedData) as $index => $key) {
             if (is_array($key)) {
                 $this->data[$index] = implode(', ', $key);
             } else {

--- a/tests/unit/ForminatorTest.php
+++ b/tests/unit/ForminatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace {
+    if (!class_exists('Forminator_CForm_Front_Action')) {
+        class Forminator_CForm_Front_Action
+        {
+            public static $prepared_data = [];
+        }
+    }
+}
+
+namespace unit {
+
+    use Forminator_CForm_Front_Action;
+    use ReflectionClass;
+    use WP_SMS\Services\Forminator\Forminator;
+    use WP_UnitTestCase;
+
+    class ForminatorTest extends WP_UnitTestCase
+    {
+        private $originalPost;
+
+        public function setUp(): void
+        {
+            parent::setUp();
+
+            $this->originalPost = $_POST;
+            $_POST = ['form_id' => '123'];
+            Forminator_CForm_Front_Action::$prepared_data = [];
+        }
+
+        public function tearDown(): void
+        {
+            $_POST = $this->originalPost;
+            Forminator_CForm_Front_Action::$prepared_data = [];
+
+            parent::tearDown();
+        }
+
+        public function testUsesForminatorPreparedDataForFieldRecipient()
+        {
+            Forminator_CForm_Front_Action::$prepared_data = [
+                'form_id' => '123',
+                'phone-1' => '+61412345678',
+            ];
+
+            $forminator = new Forminator();
+            $reflection = new ReflectionClass($forminator);
+            $setData    = $reflection->getMethod('set_data');
+            $setData->setAccessible(true);
+            $setData->invoke($forminator);
+
+            $data = $reflection->getProperty('data');
+            $data->setAccessible(true);
+
+            $this->assertSame('+61412345678', $data->getValue($forminator)['phone-1']);
+        }
+    }
+}

--- a/tests/unit/ForminatorTest.php
+++ b/tests/unit/ForminatorTest.php
@@ -55,5 +55,21 @@ namespace unit {
 
             $this->assertSame('+61412345678', $data->getValue($forminator)['phone-1']);
         }
+
+        public function testFallsBackToPostDataWhenPreparedDataIsEmpty()
+        {
+            $_POST['phone-1'] = 'recipient-from-post';
+
+            $forminator = new Forminator();
+            $reflection = new ReflectionClass($forminator);
+            $setData    = $reflection->getMethod('set_data');
+            $setData->setAccessible(true);
+            $setData->invoke($forminator);
+
+            $data = $reflection->getProperty('data');
+            $data->setAccessible(true);
+
+            $this->assertSame('recipient-from-post', $data->getValue($forminator)['phone-1']);
+        }
     }
 }


### PR DESCRIPTION
## What changed
- read submitted Forminator fields from `Forminator_CForm_Front_Action::$prepared_data`, with the existing `$_POST` path retained as a compatibility fallback
- use the configured receiver field slug against the prepared submission data
- emit a debug-only warning when the configured receiver field is unavailable, without logging submitted values
- add regression coverage for both normalized `phone-1` data and the legacy raw-post fallback
- document the fix in the 7.2.6 changelog

## Why
Current Forminator normalizes submitted fields into its prepared-data store before firing `forminator_form_after_save_entry`. Reading raw `$_POST` can therefore miss the configured phone field and silently skip the notification.

## How to test
- `FORMINATOR_SOURCE="$PWD/src/Services/Forminator/Forminator.php" php /root/phpunit.phar --bootstrap /root/wp-sms-497-test-bootstrap.php --filter ForminatorTest tests/unit/ForminatorTest.php`
- Submit a Forminator form configured with **Send SMS to field** targeting `phone-1`; confirm the SMS is sent and appears in the normal Outbox/Scheduled trace.

## Local verification
- focused Forminator regression tests: passed (2 tests, 2 assertions)
- PHP syntax checks: passed for the changed source and test files
- the focused tests were run with a minimal PHPUnit bootstrap because the sandbox's `/tmp` capacity could not fit a WordPress core test installation

Closes #497