### PR TITLE
Prepare 7.2.6 changelogs and translation template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v7.2.6 - 2026-06-**
+v7.2.6 - 2026-07-30
 - **New:** Added the LogisticSMS gateway
 - **New:** Added the `wpsms_unsubscribe_success_message` filter to customize the newsletter unsubscribe confirmation message, with the unsubscribed group passed to the filter for both the unsubscribe form and the unsubscribe link.
 - **Enhancement:** The Two-Way SMS settings page now shows the alternative path-style webhook URL for gateways that drop the query string, and links to the Two-Way SMS documentation and the setup guide for the connected gateway.

--- a/languages/wp-sms.pot
+++ b/languages/wp-sms.pot
@@ -1,0 +1,10342 @@
+# Copyright (C) 2026 VeronaLabs
+# This file is distributed under the GPL-2.0+.
+msgid ""
+msgstr ""
+"Project-Id-Version: WSMS (formerly WP SMS) 7.2.6\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-sms\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-07-29T14:24:30+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-sms\n"
+
+#. Plugin Name of the plugin
+#: wp-sms.php
+msgid "WSMS (formerly WP SMS)"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: wp-sms.php
+msgid "https://wsms.io/"
+msgstr ""
+
+#. Description of the plugin
+#: wp-sms.php
+msgid "SMS & MMS Notifications, 2FA, OTP, and Integrations with E-Commerce and Form Builders"
+msgstr ""
+
+#. Author of the plugin
+#: wp-sms.php
+msgid "VeronaLabs"
+msgstr ""
+
+#. Author URI of the plugin
+#: wp-sms.php
+msgid "https://veronalabs.com/"
+msgstr ""
+
+#. translators: 1: URL to review page 2: aria-label text 3: title text 4: link text
+#: includes/admin/class-wpsms-admin.php:44
+#: src/Admin/AdminManager.php:57
+#, php-format
+msgid "Please rate <strong>WP SMS</strong> <a href=\"%1$s\" aria-label=\"%2$s\" title=\"%3$s\" target=\"_blank\">%4$s</a> to help us spread the word. Thank you!"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:46
+#: src/Admin/AdminManager.php:59
+msgid "Rate WP SMS with five stars on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:47
+#: src/Admin/AdminManager.php:60
+msgid "Rate WP SMS"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:48
+#: src/Admin/AdminManager.php:61
+msgid "on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:62
+#: src/Admin/AdminManager.php:75
+#: resources/react/src/pages/PhoneConfig.jsx:106
+msgid "WordPress"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:63
+#: src/Admin/SiteHealthInfo.php:24
+#: src/Blocks/BlockAssetsManager.php:48
+msgid "WP SMS"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:92
+#: includes/class-front.php:36
+#: includes/class-wpsms-gateway.php:322
+#: includes/gateways/class-wpsms-gateway-tubelightcommunications.php:50
+#: includes/templates/admin/fields/field-team-member-repeater.php:43
+#: includes/templates/admin/fields/field-team-member-repeater.php:87
+#: includes/templates/admin/user-profile-fields.php:2
+msgid "SMS"
+msgstr ""
+
+#. translators: %s: Number of subscribers
+#: includes/admin/class-wpsms-admin.php:107
+#, php-format
+msgid "%s Subscriber"
+msgstr ""
+
+#. translators: %s: SMS credit
+#: includes/admin/class-wpsms-admin.php:110
+#, php-format
+msgid "%s SMS Credit"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:126
+msgid "Click here to rate and review this plugin on WordPress.org"
+msgstr ""
+
+#: includes/admin/class-wpsms-admin.php:126
+msgid "Rate this plugin"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings-integration.php:28
+#: resources/react/src/pages/Integrations.jsx:871
+#: resources/react/src/pages/Integrations.jsx:931
+msgid "Contact Form 7"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:184
+#: src/Services/Report/EmailReportGenerator.php:120
+msgid "General"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:185
+#: resources/react/src/components/wizard/SetupWizard.jsx:97
+#: resources/react/src/components/wizard/steps/SmsGatewayStep.jsx:30
+#: resources/react/src/components/wizard/WizardStepper.jsx:11
+#: resources/react/src/pages/Gateway.jsx:289
+#: resources/react/src/pages/Overview.jsx:122
+msgid "SMS Gateway"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:186
+msgid "SMS Newsletter"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:187
+#: resources/react/src/lib/pageRegistry.js:143
+#: resources/react/src/pages/Overview.jsx:145
+msgid "Notifications"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:188
+#: includes/admin/settings/class-wpsms-settings.php:738
+#: resources/react/src/lib/pageRegistry.js:137
+#: resources/react/src/pages/Overview.jsx:136
+msgid "Message Button"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:189
+msgid "Advanced Options"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:194
+#: resources/react/src/lib/pageRegistry.js:162
+#: resources/react/src/pages/Integrations.jsx:1224
+#: resources/react/src/pages/Overview.jsx:147
+msgid "Integrations"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:308
+msgid "Default Country Code is required when International Number Input is disabled. Please set it on the General tab so phone numbers can be interpreted correctly."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:318
+msgid "Settings Successfully Saved."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:334
+#: includes/templates/admin/fields/field-wc-status-repeater.php:26
+#: includes/templates/admin/fields/field-wc-status-repeater.php:59
+msgid "Enable"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:335
+#: includes/admin/settings/class-wpsms-settings.php:385
+#: includes/templates/admin/fields/field-wc-status-repeater.php:27
+#: includes/templates/admin/fields/field-wc-status-repeater.php:60
+msgid "Disable"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:339
+#: resources/react/src/pages/TwoWaySettings.jsx:461
+msgid "30 days"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:340
+#: resources/react/src/pages/TwoWaySettings.jsx:462
+msgid "90 days"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:341
+#: resources/react/src/pages/TwoWaySettings.jsx:463
+msgid "180 days"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:342
+msgid "365 days"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:343
+#: resources/react/src/pages/Advanced.jsx:126
+#: resources/react/src/pages/TwoWaySettings.jsx:465
+msgid "Keep forever"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:350
+#: resources/react/src/pages/Newsletter.jsx:88
+#: resources/react/src/pages/TwoWayInbox.jsx:597
+#: resources/react/src/pages/TwoWayInbox.jsx:600
+msgid "All"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:365
+#: resources/react/src/pages/PhoneConfig.jsx:58
+msgid "Administrator Notifications"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:370
+msgid "Admin Mobile Number"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:372
+msgid "Mobile number where the administrator will receive notifications."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:376
+#: resources/react/src/pages/PhoneConfig.jsx:90
+msgid "Mobile Field Configuration"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:381
+#: src/Admin/SiteHealthInfo.php:65
+msgid "Mobile Number Field Source"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:386
+msgid "Insert a mobile number field into user profiles"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:389
+msgid "Add a mobile number field to billing and checkout pages"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:390
+msgid "Use the existing billing phone field"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:393
+msgid "Create a new mobile number field or use an existing phone field."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:397
+#: src/Admin/SiteHealthInfo.php:71
+msgid "Mobile Field Mandatory Status"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:400
+#: src/Admin/SiteHealthInfo.php:72
+msgid "Required"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:401
+#: src/Admin/SiteHealthInfo.php:72
+msgid "Optional"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:403
+msgid "Set the mobile number field as optional or required."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:407
+msgid "Mobile Field Placeholder"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:409
+msgid "Enter a sample format for the mobile number that users will see. Example: \"e.g., +1234567890\"."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:413
+#: src/Admin/SiteHealthInfo.php:78
+msgid "International Number Input"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:416
+msgid "Add a flag dropdown for international format support in the mobile number input field."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:420
+#: src/Admin/SiteHealthInfo.php:85
+msgid "Only Countries"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:424
+msgid "In the dropdown, display only the countries you specify."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:428
+#: src/Admin/SiteHealthInfo.php:92
+#: resources/react/src/pages/PhoneConfig.jsx:218
+msgid "Preferred Countries"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:432
+msgid "Specify the countries to appear at the top of the list."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:436
+#: includes/admin/settings/class-wpsms-settings.php:441
+msgid "Country Code Prefix"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:439
+msgid "If the user's mobile number requires a country code, select it from the list. If the number is not specific to any country, select 'No country code (Global / Local)'."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:440
+msgid "No country code (Global / Local)"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:445
+msgid "Minimum Length Number"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:448
+msgid "Specify the shortest allowed mobile number."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:452
+msgid "Maximum Length Number"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:455
+msgid "Specify the longest allowed mobile number."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:460
+#: includes/admin/settings/class-wpsms-settings.php:1281
+msgid "Data Protection Settings"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:461
+msgid "Enhance user privacy with GDPR-focused settings. Activate to ensure compliance with data protection regulations and provide users with transparency and control over their personal information."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:467
+msgid "GDPR Compliance Enhancements"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:470
+msgid "Implements GDPR adherence by enabling user data export and deletion via mobile number and adding a consent checkbox for SMS newsletter subscriptions."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:481
+msgid "SMS Gateway Setup"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:486
+msgid "Choose the Gateway"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:489
+msgid "Select your preferred SMS Gateway to send messages."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:493
+#: resources/react/src/pages/Gateway.jsx:631
+msgid "Gateway Guide"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:499
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:73
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:100
+msgid "API Username"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:501
+msgid "e.g., YourGatewayUsername123"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:502
+msgid "Enter the username provided by your SMS gateway."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:506
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:78
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:105
+msgid "API Password"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:508
+msgid "Enter API password of gateway"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:512
+msgid "Sender ID/Number"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:515
+msgid "This is the number or sender ID displayed on recipients' devices. It might be a phone number (e.g., +1 555 123 4567) or an alphanumeric ID if supported by your gateway."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:519
+#: includes/gateways/class-wpsms-gateway-farazsms.php:90
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:44
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:110
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:92
+#: includes/gateways/class-wpsms-gateway-octopush.php:39
+#: includes/gateways/class-wpsms-gateway-sms.php:90
+#: includes/gateways/class-wpsms-gateway-smsozone.php:29
+msgid "API Key"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:521
+#: includes/gateways/class-wpsms-gateway-prosms.php:34
+#: includes/gateways/class-wpsms-gateway-prosmsdk.php:34
+msgid "Enter API key of gateway"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:525
+msgid "WP SMS Setup Wizard"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:529
+msgid "Re-run Setup Wizard"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:532
+msgid "Need to debug or update your gateway settings? Relaunch the WP SMS Setup Wizard for a guided, step-by-step process. This will help you verify your credentials, test sending/receiving capabilities, and ensure everything is running smoothly."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:537
+msgid "Gateway Overview"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:542
+#: includes/admin/settings/class-wpsms-settings.php:702
+#: includes/admin/settings/class-wpsms-settings.php:997
+#: includes/admin/settings/class-wpsms-settings.php:1088
+#: includes/admin/settings/class-wpsms-settings.php:1117
+#: includes/admin/settings/class-wpsms-settings.php:1133
+#: includes/admin/settings/class-wpsms-settings.php:1161
+#: includes/admin/settings/class-wpsms-settings.php:1183
+#: includes/admin/settings/class-wpsms-settings.php:1216
+#: includes/api/v1/class-wpsms-api-outbox.php:604
+#: includes/templates/admin/subscriber-form.php:54
+#: includes/templates/email/partials/report-data.php:48
+#: src/Services/Formidable/FormidableManager.php:49
+#: resources/react/src/lib/tableColumns.jsx:59
+#: resources/react/src/pages/Outbox.jsx:585
+#: resources/react/src/pages/Scheduled.jsx:504
+#: resources/react/src/pages/Scheduled.jsx:1086
+#: resources/react/src/pages/SmsCampaigns.jsx:277
+#: resources/react/src/pages/SmsCampaigns.jsx:507
+#: resources/react/src/pages/SmsCampaigns.jsx:939
+#: resources/react/src/pages/SmsCampaigns.jsx:1042
+#: resources/react/src/pages/Subscribers.jsx:423
+#: resources/react/src/pages/Subscribers.jsx:732
+#: resources/react/src/pages/Subscribers.jsx:955
+#: resources/react/src/pages/TwoWayCommands.jsx:299
+#: resources/react/src/pages/TwoWayCommands.jsx:551
+#: resources/react/src/pages/TwoWayCommands.jsx:558
+#: resources/react/src/pages/TwoWayInbox.jsx:690
+msgid "Status"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:548
+msgid "Balance / Credit"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:554
+msgid "Incoming Message"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:560
+msgid "Send Bulk SMS"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:566
+#: includes/admin/settings/class-wpsms-settings.php:1060
+msgid "Send MMS"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:573
+msgid "Account Balance Visibility"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:578
+msgid "Admin Menu Display"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:581
+msgid "Shows account credit in the admin menu."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:585
+msgid "SMS Page Display"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:588
+msgid "Displays account credit on the SMS sending page."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:593
+msgid "SMS Dispatch & Number Optimization"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:598
+#: resources/react/src/pages/Gateway.jsx:809
+msgid "Delivery Method"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:601
+#: resources/react/src/pages/Gateway.jsx:815
+msgid "Send SMS Instantly: Activates immediate dispatch of messages via API upon request."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:602
+#: resources/react/src/pages/Gateway.jsx:816
+msgid "Scheduled SMS Delivery: Configures API to send messages at predetermined times."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:603
+#: resources/react/src/pages/Gateway.jsx:817
+msgid "Batch SMS Queue: Lines up messages for grouped sending, enhancing efficiency for bulk dispatch."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:605
+#: resources/react/src/pages/Gateway.jsx:810
+msgid "Select the dispatch method for SMS messages: instant send via API, delayed send at set times, or batch send for large recipient lists. For lists exceeding 20 recipients, batch sending is automatically selected."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:609
+msgid "Unicode Messaging"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:612
+msgid "Send messages in languages that use non-English characters, like Persian, Arabic, Chinese, or Cyrillic."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:616
+msgid "Number Formatting"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:619
+msgid "Strips spaces from phone numbers before sending."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:623
+msgid "Restrict to Local Numbers"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:626
+msgid "Send messages to numbers within the same country to avoid international fees."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:630
+msgid "Allowed Countries for SMS"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:636
+msgid "Specify countries allowed for SMS delivery. Only listed countries will receive messages."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:648
+#: resources/react/src/pages/Newsletter.jsx:47
+msgid "SMS Newsletter Configuration"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:649
+msgid "Configure how visitors subscribe to your SMS notifications."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:656
+msgid "Group Visibility in Form"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:658
+msgid "Show available groups on the subscription form."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:662
+msgid "Group Selection"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:665
+#: resources/react/src/pages/Newsletter.jsx:65
+msgid "Allow subscribers to join multiple groups from the form."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:669
+msgid "Groups to Display"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:675
+msgid "Choose which groups appear on the subscription form."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:679
+msgid "Default Group for New Subscribers"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:683
+msgid "Set a group that all new subscribers will join by default."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:687
+msgid "Subscription Confirmation"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:689
+msgid "Subscribers must enter a code received by SMS to complete their subscription."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:694
+msgid "Welcome SMS Setup"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:695
+msgid "Set up automatic SMS messages for new subscribers."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:704
+msgid "Sends a welcome SMS to new subscribers when they sign up."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:708
+msgid "Welcome Message Content"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:710
+msgid "Customize the SMS message sent to new subscribers. Use placeholders for personalized details: "
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:715
+msgid "Appearance Customization"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:720
+msgid "Disable Default Form Styling"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:722
+msgid "Remove the plugin's default styling from the subscription form if preferred."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:733
+#: resources/react/src/pages/MessageButton.jsx:439
+msgid "Message Button Configuration"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:741
+msgid "Switch on to display the Message Button on your site or off to hide it. <a href=\"#\" class=\"js-wpsms-chatbox-preview\">Preview</a>"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:745
+#: includes/templates/widget.php:3
+#: resources/blocks/send-sms/edit.js:121
+#: resources/blocks/subscribe/edit.js:55
+#: resources/react/src/pages/MessageButton.jsx:731
+msgid "Title"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:747
+msgid "Main title for your chatbox, e.g., 'Chat with Us!'"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:752
+#: resources/react/src/pages/MessageButton.jsx:483
+msgid "Button Appearance"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:757
+msgid "Text"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:759
+msgid "The message displayed on the chat button, e.g., 'Talk to Us'"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:763
+#: resources/react/src/pages/MessageButton.jsx:499
+msgid "Button Style"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:766
+#: resources/react/src/pages/MessageButton.jsx:505
+msgid "Icon & Text"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:767
+#: resources/react/src/pages/MessageButton.jsx:506
+msgid "Icon Only"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:768
+#: resources/react/src/pages/MessageButton.jsx:507
+msgid "Text Only"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:770
+#: resources/react/src/pages/MessageButton.jsx:503
+msgid "Choose how the floating button appears."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:774
+msgid "Position"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:777
+#: resources/react/src/pages/MessageButton.jsx:518
+msgid "Bottom Right"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:778
+#: resources/react/src/pages/MessageButton.jsx:519
+msgid "Bottom Left"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:780
+msgid "Choose where the chat button appears on your site."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:785
+msgid "Support Team Profiles"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:790
+msgid "Team Members"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:799
+msgid "Additional Chatbox Options"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:804
+msgid "Chatbox Color"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:806
+msgid "Choose your chat button's background color and header color."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:810
+msgid "Chatbox Text Color"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:812
+msgid "Select the color for your button and header text."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:816
+msgid "Footer Text"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:818
+msgid "Text displayed in the chatbox footer, such as 'Chat with us on WhatsApp for instant support!'"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:822
+#: resources/react/src/pages/MessageButton.jsx:619
+msgid "Footer Text Color"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:824
+msgid "Select your footer text color."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:828
+msgid "Footer Link Title"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:830
+msgid "Include a link for more information in the chatbox footer, e.g., 'Related Articles'"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:834
+#: resources/react/src/pages/MessageButton.jsx:645
+msgid "Footer Link URL"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:836
+msgid "Enter the URL of the chatbox footer link."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:840
+msgid "Animation Effect"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:843
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:390
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:391
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:542
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:543
+#: resources/react/src/pages/MessageButton.jsx:530
+msgid "None"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:844
+#: resources/react/src/pages/MessageButton.jsx:531
+msgid "Fade In"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:845
+#: resources/react/src/pages/MessageButton.jsx:532
+msgid "Slide Up"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:847
+msgid "Choose an effect for the chatbox's entry or hover state."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:851
+msgid "Disable WP SMS Logo"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:854
+msgid "Check this box to disable the WP SMS logo in the footer of the chatbox."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:859
+msgid "Informational Links"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:864
+#: resources/react/src/pages/MessageButton.jsx:726
+msgid "Resource Links"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:867
+msgid "Turn on to show resource links in the chatbox."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:871
+msgid "Section Title"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:873
+msgid "The heading for your resource links, e.g., 'Quick Links'"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:877
+msgid "Links"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:891
+#: resources/react/src/pages/Advanced.jsx:138
+msgid "Administrative Reporting"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:896
+#: src/Admin/SiteHealthInfo.php:196
+msgid "SMS Performance Reports"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:899
+msgid "Sends weekly SMS performance statistics to the admin email."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:903
+msgid "SMS Transmission Error Alerts"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:906
+msgid "Notifies the admin email upon SMS transmission failures."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:910
+#: resources/react/src/pages/Advanced.jsx:166
+msgid "Plugin Notifications"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:915
+msgid "WP SMS Notifications"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:919
+msgid "Display important notifications inside the plugin about new versions, feature updates, news, and special offers."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:924
+msgid "Webhooks Configuration"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:925
+msgid "Set up your system's Webhook URLs to integrate with external services."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:932
+#: resources/react/src/pages/Advanced.jsx:55
+msgid "Outgoing SMS Webhook"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:934
+msgid "Configure the Webhook URL to which notifications are sent after an SMS dispatch from your system. Please enter a secure URL (HTTPS)."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:938
+msgid "Subscriber Registration Webhook"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:940
+msgid "Provide the Webhook URL that will be triggered when a new subscriber registers. Ensure the URL uses the HTTPS protocol."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:944
+msgid "Incoming SMS Handling Webhook"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:946
+msgid "Define the Webhook URL for the \"<a href=\"https://wsms.io/addons/two-way?utm_source=wp-sms&utm_medium=link&utm_campaign=settings\" target=\"_blank\">Two-Way SMS</a>\" add-on that handles incoming SMS messages. Only secure HTTPS URLs are accepted."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:946
+msgid "Please provide each Webhook URL on a separate line if you're setting up more than one."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:950
+#: resources/react/src/pages/Advanced.jsx:187
+msgid "Anonymous Usage Data"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:955
+#: resources/react/src/pages/Advanced.jsx:195
+msgid "Share Anonymous Data"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:958
+msgid "Sends non-personal, anonymized data to help us improve WP SMS. No personal or identifying information is collected or shared. <a href=\"https://wsms.io/docs/share-anonymous-data/?utm_source=wp-sms&utm_medium=link&utm_campaign=settings\" target=\"_blank\">Learn More</a>."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:962
+msgid "Message Storage & Cleanup"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:967
+msgid "Store Outbox Messages"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:970
+msgid "If disabled, new SMS will not be logged in the Outbox."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:974
+msgid "Delete Outbox Messages Older Than"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:978
+msgid "Runs daily at 00:00 (site time). Choose how long to retain Outbox messages."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:990
+msgid "New Post Alerts"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:991
+msgid "Configure SMS notifications to inform subscribers about newly published content."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1000
+msgid "Send SMS for new posts."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1004
+#: includes/admin/settings/class-wpsms-settings.php:1095
+msgid "Post Types"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1007
+msgid "Specify which types of content trigger notifications."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1011
+msgid "Taxonomies and Terms"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1014
+msgid "Choose categories or tags to associate with alerts."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1018
+msgid "Notification Recipients"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1021
+#: includes/templates/meta-box.php:14
+#: src/Controller/NumberMigrationAjax.php:79
+#: resources/react/src/lib/pageRegistry.js:88
+#: resources/react/src/pages/Groups.jsx:234
+#: resources/react/src/pages/Notifications.jsx:139
+msgid "Subscribers"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1022
+#: includes/admin/settings/class-wpsms-settings.php:1045
+msgid "Individual Numbers"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1023
+#: resources/react/src/pages/Notifications.jsx:141
+#: resources/react/src/pages/Notifications.jsx:173
+msgid "User Roles"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1025
+msgid "Select who receives notifications."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1029
+msgid "Subscribe Group"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1033
+msgid "Set the default group to receive notifications."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1037
+#: includes/admin/settings/class-wpsms-settings.php:1190
+msgid "Specific Roles"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1041
+msgid "Assign SMS alerts to specific WordPress user roles."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1048
+msgid "Enter mobile number(s) here to receive SMS alerts. For multiple numbers, separate them with commas."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1052
+msgid "Force Send"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1055
+msgid "Use to send notifications without additional confirmation during publishing. Compatible with WP-REST API."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1063
+msgid "Sends the featured image of the post as an MMS if supported by your SMS gateway."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1067
+#: includes/admin/settings/class-wpsms-settings.php:1102
+#: includes/admin/settings/class-wpsms-settings.php:1168
+#: includes/admin/settings/class-wpsms-settings.php:1197
+msgid "Message Body"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1069
+msgid "Define the SMS format."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1073
+msgid "Post Content Words Limit"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1075
+msgid "Set maximum word count for post excerpts in notifications. Default: 10."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1081
+msgid "Post Author Notification"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1082
+msgid "Set up notifications for post authors when their content is published. Ensure the mobile number field is added to user profiles under Settings > General > Mobile Number Field Source."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1091
+msgid "Alerts post authors via SMS after publishing their posts."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1098
+msgid "Define which content types trigger author notifications."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1104
+msgid "Customize the SMS message to authors using placeholders for post details."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1110
+msgid "The new release of WordPress"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1111
+msgid "Configure notifications to be sent via SMS to the Admin Mobile Number regarding new releases of WordPress."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1120
+msgid "Notifications for new WordPress releases."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1126
+msgid "Register a new user"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1127
+msgid "Set up SMS notifications for admin and new user upon registration."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1136
+msgid "SMS notifications for new user registrations."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1140
+msgid "Message Body for Admin"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1142
+msgid "Customize the SMS template sent to the Admin Mobile Number for new user registrations using placeholders for user details."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1146
+msgid "Message Body for User"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1148
+msgid "Customize the SMS template sent to the user upon registration using placeholders for personal details."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1154
+msgid "New Comment Notification"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1155
+msgid "Receive SMS alerts on the Admin Mobile Number when a new comment is posted."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1164
+msgid "Receiving SMS alerts on the Admin Mobile Number for each new comment."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1170
+msgid "Create the SMS message for new comment alerts. Include details using placeholders:"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1176
+msgid "User Login Notification"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1177
+msgid "Configure SMS notifications to be sent to the Admin Mobile Number whenever a user logs in."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1186
+msgid "SMS notifications to be sent to the Admin Mobile Number on user login."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1193
+msgid "Choose user roles that trigger login notifications."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1199
+msgid "Format the SMS message sent upon user login. Utilize placeholders to include user details:"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1209
+#: src/Services/Formidable/FormidableManager.php:42
+msgid "SMS Notification Metabox"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1212
+#: src/Services/Formidable/FormidableManager.php:45
+msgid "By this option you can add SMS notification tools in all edit forms."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1219
+msgid "This option adds SMS Notification tab in the edit forms."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1282
+msgid "Set up how you comply with data protection regulations"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1289
+msgid "Consent Text"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1291
+msgid "Provide a clear message that informs subscribers how their data will be used and that their consent is required. For example: \"I agree to receive SMS notifications and understand that my data will be handled according to the privacy policy.\""
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1296
+msgid "Checkbox Default"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1299
+msgid "Leave the consent checkbox unchecked by default to comply with privacy laws, which require active, explicit consent from users."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1304
+#: resources/react/src/pages/PhoneConfig.jsx:309
+msgid "GDPR Compliance"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1306
+msgid "To get more option for GDPR, you should enable that in the general tab."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1359
+#: resources/react/src/components/layout/Sidebar.jsx:23
+msgid "Documentation"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1396
+#: includes/class-wpsms-gateway.php:548
+#: includes/templates/admin/subscriber-form.php:57
+#: includes/templates/admin/subscriber-form.php:60
+#: includes/templates/email/partials/report-data.php:74
+#: src/Admin/SiteHealthInfo.php:107
+#: src/Controller/OnBoardingTestGateway.php:65
+#: src/Service/Assets/Handlers/AdminHandler.php:269
+#: resources/react/src/components/modals/AllInOneModal.jsx:138
+#: resources/react/src/lib/tableColumns.jsx:64
+#: resources/react/src/lib/tableColumns.jsx:322
+#: resources/react/src/lib/tableColumns.jsx:324
+#: resources/react/src/lib/tableColumns.jsx:563
+#: resources/react/src/pages/Integrations.jsx:26
+#: resources/react/src/pages/Privacy.jsx:171
+#: resources/react/src/pages/Scheduled.jsx:939
+#: resources/react/src/pages/Scheduled.jsx:997
+#: resources/react/src/pages/Scheduled.jsx:1088
+#: resources/react/src/pages/SmsCampaigns.jsx:61
+#: resources/react/src/pages/SmsCampaigns.jsx:284
+#: resources/react/src/pages/SmsCampaigns.jsx:839
+#: resources/react/src/pages/Subscribers.jsx:426
+#: resources/react/src/pages/Subscribers.jsx:664
+#: resources/react/src/pages/Subscribers.jsx:736
+msgid "Active"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1598
+msgid "- (All-in-One Required)"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1702
+msgid "Upload File"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1789
+#: resources/react/src/lib/pageRegistry.js:319
+msgid "ADD-ONS"
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1803
+#: includes/admin/settings/class-wpsms-settings.php:1811
+msgid "Upgrade to unlock everything."
+msgstr ""
+
+#. translators: %s: Plugin name (WP SMS All-in-One)
+#: includes/admin/settings/class-wpsms-settings.php:1806
+#, php-format
+msgid "Full integration support is available in %s, including WooCommerce, BuddyPress, Gravity Forms and more."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:1807
+#: includes/admin/settings/class-wpsms-settings.php:1815
+msgid "WP SMS All-in-One"
+msgstr ""
+
+#. translators: %s: Plugin name (WP SMS All-in-One)
+#: includes/admin/settings/class-wpsms-settings.php:1814
+#, php-format
+msgid "Some settings are only available in %s, including extended field support, syncing options, and more advanced configuration."
+msgstr ""
+
+#: includes/admin/settings/class-wpsms-settings.php:2010
+msgid "Please select your gateway"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-addons.php:149
+msgid "Add-ons retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-addons.php:172
+#: resources/react/src/pages/AddOns.jsx:48
+msgid "License activated successfully."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-addons.php:191
+msgid "No license found for this add-on."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-addons.php:196
+#: resources/react/src/pages/AddOns.jsx:62
+msgid "License removed successfully."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-admin-notices.php:147
+#: includes/api/v1/class-wpsms-api-admin-notices.php:201
+msgid "Invalid parameters"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-admin-notices.php:185
+msgid "Notice dismissed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-admin-notices.php:206
+msgid "Modal marked as seen"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-admin-notices.php:225
+msgid "Unsupported action type"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-admin-notices.php:230
+msgid "Option not allowed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-admin-notices.php:246
+msgid "Action executed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:66
+msgid "Array of group IDs to delete"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:136
+msgid "Groups retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:157
+#: includes/api/v1/class-wpsms-api-groups.php:221
+#: includes/api/v1/class-wpsms-api-groups.php:262
+#: includes/api/v1/class-wpsms-api-groups.php:308
+msgid "Group not found"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:168
+msgid "Group retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:184
+#: includes/api/v1/class-wpsms-api-groups.php:225
+msgid "Group name is required"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:196
+#: includes/api/v1/class-wpsms-api-groups.php:238
+msgid "A group with this name already exists"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:202
+msgid "Failed to create group"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:205
+#: resources/react/src/pages/Groups.jsx:90
+msgid "Group created successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:244
+msgid "Failed to update group"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:247
+#: resources/react/src/pages/Groups.jsx:117
+msgid "Group updated successfully"
+msgstr ""
+
+#. translators: %d: number of subscribers in the group
+#: includes/api/v1/class-wpsms-api-groups.php:271
+#, php-format
+msgid "Cannot delete group. It has %d subscriber(s). Please move or delete them first."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:281
+msgid "Failed to delete group"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:284
+#: resources/react/src/pages/Groups.jsx:44
+msgid "Group deleted successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:295
+msgid "No group IDs provided"
+msgstr ""
+
+#. translators: %d: number of subscribers in the group
+#: includes/api/v1/class-wpsms-api-groups.php:320
+#, php-format
+msgid "Group has %d subscriber(s)"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:334
+#: resources/react/src/hooks/useListPage.js:49
+msgid "Failed to delete"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-groups.php:340
+msgid "Failed to delete any groups"
+msgstr ""
+
+#. translators: %d: number of groups deleted
+#: includes/api/v1/class-wpsms-api-groups.php:348
+#, php-format
+msgid "%d group(s) deleted successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-newsletter.php:129
+#: includes/api/v1/class-wpsms-api-newsletter.php:186
+#: src/Controller/PublicSubscribeAjax.php:40
+msgid "Please select a specific group."
+msgstr ""
+
+#. translators: %s: Group ID
+#: includes/api/v1/class-wpsms-api-newsletter.php:151
+#, php-format
+msgid "Group ID #%s is not valid"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-newsletter.php:199
+msgid "Your mobile number has been successfully unsubscribed."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-newsletter.php:229
+#: src/Controller/PublicVerifySubscribeAjax.php:46
+#: src/Services/Subscriber/SubscriberUtil.php:91
+msgid "Your mobile number has been successfully subscribed."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-notifications.php:108
+msgid "Notifications retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-notifications.php:126
+msgid "Missing notification ID"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-notifications.php:131
+msgid "All notifications dismissed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-notifications.php:137
+msgid "Invalid notification ID"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-notifications.php:142
+msgid "Notification dismissed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:272
+msgid "Outbox retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:335
+#: includes/api/v1/class-wpsms-api-outbox.php:372
+#: includes/api/v1/class-wpsms-api-outbox.php:404
+msgid "Message not found"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:342
+msgid "Message retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:382
+msgid "Failed to delete message"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:385
+#: resources/react/src/pages/Outbox.jsx:61
+#: resources/react/src/pages/Outbox.jsx:72
+msgid "Message deleted successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:411
+#: includes/api/v1/class-wpsms-api-outbox.php:498
+msgid "SMS gateway not configured"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:418
+msgid "No valid recipients found"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:452
+#: resources/react/src/pages/Outbox.jsx:163
+msgid "Message resent successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:469
+#: includes/api/v1/class-wpsms-api-subscribers.php:595
+#: resources/react/src/hooks/useListPage.js:52
+msgid "No items selected"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:493
+msgid "You do not have permission to send SMS"
+msgstr ""
+
+#. translators: %1$d: message ID, %2$s: error message
+#: includes/api/v1/class-wpsms-api-outbox.php:531
+#: includes/api/v1/class-wpsms-api-outbox.php:535
+#, php-format
+msgid "Failed to resend message #%1$d: %2$s"
+msgstr ""
+
+#. translators: %d: number of messages processed
+#: includes/api/v1/class-wpsms-api-outbox.php:548
+#: resources/react/src/pages/Scheduled.jsx:190
+#, php-format,js-format
+msgid "%d message(s) processed successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:599
+#: includes/templates/admin/group-form.php:9
+#: src/Service/Assets/Handlers/AdminHandler.php:242
+#: resources/react/src/pages/Groups.jsx:166
+msgid "ID"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:600
+#: src/Service/Assets/Handlers/AdminHandler.php:235
+#: resources/react/src/lib/tableColumns.jsx:19
+#: resources/react/src/pages/TwoWayInbox.jsx:375
+msgid "Date"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:601
+#: includes/gateways/class-wpsms-gateway-octopush.php:44
+#: resources/react/src/pages/Outbox.jsx:599
+#: resources/react/src/pages/Scheduled.jsx:518
+#: resources/react/src/pages/Scheduled.jsx:651
+#: resources/react/src/pages/Scheduled.jsx:1219
+#: resources/react/src/pages/TwoWayInbox.jsx:324
+#: resources/react/src/pages/TwoWayInbox.jsx:682
+msgid "Sender"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:602
+#: resources/react/src/lib/tableColumns.jsx:173
+#: resources/react/src/lib/tableColumns.jsx:411
+#: resources/react/src/lib/tableColumns.jsx:537
+#: resources/react/src/pages/TwoWayInbox.jsx:748
+msgid "Recipient"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:603
+#: includes/templates/admin/order-view-metabox.php:22
+#: includes/templates/admin/quick-reply.php:25
+#: includes/templates/send-sms-form.php:17
+#: includes/templates/send-sms-form.php:45
+#: resources/blocks/send-sms/edit.js:133
+#: resources/react/src/components/shared/MessageComposer.jsx:108
+#: resources/react/src/lib/tableColumns.jsx:196
+#: resources/react/src/lib/tableColumns.jsx:423
+#: resources/react/src/lib/tableColumns.jsx:549
+#: resources/react/src/pages/Outbox.jsx:616
+#: resources/react/src/pages/Outbox.jsx:704
+#: resources/react/src/pages/Scheduled.jsx:535
+#: resources/react/src/pages/Scheduled.jsx:661
+#: resources/react/src/pages/Scheduled.jsx:1122
+#: resources/react/src/pages/Scheduled.jsx:1229
+#: resources/react/src/pages/TwoWayInbox.jsx:347
+#: resources/react/src/pages/TwoWayInbox.jsx:711
+#: resources/react/src/pages/TwoWayInbox.jsx:758
+msgid "Message"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:605
+#: resources/react/src/pages/SmsCampaigns.jsx:1058
+#: resources/react/src/pages/SmsCampaigns.jsx:1114
+msgid "Response"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:611
+#: includes/templates/admin/dashboard-widget.php:41
+#: includes/templates/email/partials/report-data.php:107
+#: src/Service/Assets/Handlers/AdminHandler.php:273
+#: src/Widget/Widgets/StatsWidget.php:145
+#: resources/react/src/lib/tableColumns.jsx:62
+#: resources/react/src/lib/tableColumns.jsx:201
+#: resources/react/src/lib/tableColumns.jsx:202
+#: resources/react/src/lib/tableColumns.jsx:429
+#: resources/react/src/pages/Outbox.jsx:396
+#: resources/react/src/pages/Outbox.jsx:489
+#: resources/react/src/pages/Outbox.jsx:587
+#: resources/react/src/pages/Privacy.jsx:166
+#: resources/react/src/pages/Scheduled.jsx:359
+#: resources/react/src/pages/Scheduled.jsx:408
+#: resources/react/src/pages/Scheduled.jsx:506
+#: resources/react/src/pages/SmsCampaigns.jsx:87
+#: resources/react/src/pages/SmsCampaigns.jsx:1077
+#: resources/react/src/pages/SmsCampaigns.jsx:1122
+#: resources/react/src/pages/TwoWayInbox.jsx:368
+#: resources/react/src/pages/TwoWayInbox.jsx:576
+#: resources/react/src/pages/TwoWayInbox.jsx:694
+#: resources/react/src/pages/TwoWayInbox.jsx:841
+msgid "Failed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:611
+#: resources/react/src/lib/tableColumns.jsx:61
+#: resources/react/src/lib/tableColumns.jsx:200
+#: resources/react/src/lib/tableColumns.jsx:428
+#: resources/react/src/lib/tableColumns.jsx:553
+#: resources/react/src/pages/CartAbandonment.jsx:61
+#: resources/react/src/pages/Outbox.jsx:383
+#: resources/react/src/pages/Outbox.jsx:488
+#: resources/react/src/pages/Outbox.jsx:587
+#: resources/react/src/pages/Privacy.jsx:166
+#: resources/react/src/pages/Scheduled.jsx:344
+#: resources/react/src/pages/Scheduled.jsx:407
+#: resources/react/src/pages/Scheduled.jsx:506
+#: resources/react/src/pages/Scheduled.jsx:1093
+#: resources/react/src/pages/SmsCampaigns.jsx:1075
+#: resources/react/src/pages/SmsCampaigns.jsx:1120
+#: resources/react/src/pages/TwoWayInbox.jsx:841
+msgid "Sent"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-outbox.php:626
+msgid "Export generated successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-privacy.php:115
+#: includes/api/v1/class-wpsms-api-privacy.php:235
+#: includes/api/v1/class-wpsms-api-privacy.php:290
+msgid "Invalid phone number"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-privacy.php:122
+#: includes/api/v1/class-wpsms-api-privacy.php:242
+#: resources/react/src/pages/Privacy.jsx:69
+msgid "No data found for this phone number"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-privacy.php:128
+msgid "Data found"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-privacy.php:213
+#: resources/react/src/pages/Privacy.jsx:136
+msgid "SMS Message"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-privacy.php:273
+#: includes/api/v1/class-wpsms-api-subscribers.php:709
+msgid "Export data ready"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-privacy.php:295
+msgid "Deletion must be confirmed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-privacy.php:340
+msgid "No data found to delete for this phone number"
+msgstr ""
+
+#. translators: %1$d: number of records deleted, %2$s: phone number
+#: includes/api/v1/class-wpsms-api-privacy.php:345
+#, php-format
+msgid "Successfully deleted %1$d record(s) for %2$s"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:153
+#: includes/api/v1/class-wpsms-api-send.php:455
+msgid "Could not find any mobile numbers."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:157
+#: includes/api/v1/class-wpsms-api-send.php:418
+msgid "The message body can not be empty."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:181
+#: includes/api/v1/class-wpsms-api-send.php:219
+#: includes/api/v1/class-wpsms-api-send.php:478
+#: includes/api/v1/class-wpsms-api-send.php:535
+msgid "Selected start date must be in future"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:185
+#: includes/api/v1/class-wpsms-api-send.php:482
+msgid "Selected end date must be after start date"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:207
+#: includes/api/v1/class-wpsms-api-send.php:517
+msgid "Repeating SMS is scheduled successfully!"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:210
+#: includes/api/v1/class-wpsms-api-send.php:524
+msgid "Repeating SMS requires the WP SMS Pro add-on. Please install and activate the add-on to use this feature."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:238
+#: includes/api/v1/class-wpsms-api-send.php:564
+msgid "SMS scheduled successfully!"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:241
+#: includes/api/v1/class-wpsms-api-send.php:571
+msgid "Scheduled SMS requires the WP SMS Pro add-on. Please install and activate the add-on to use this feature."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:264
+#: includes/api/v1/class-wpsms-api-send.php:589
+msgid "Failed to send SMS. An unexpected error occurred. Please try again or check your gateway settings."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:267
+msgid "Successfully send SMS!"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:295
+msgid "Parameter group_ids is required"
+msgstr ""
+
+#. translators: %s: Group ID
+#: includes/api/v1/class-wpsms-api-send.php:302
+#, php-format
+msgid "The group ID %s is not valid"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:320
+msgid "Parameter role_ids is required"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:339
+msgid "Parameter users is required"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:353
+msgid "WooCommerce or WP-SMS Pro is not enabled"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:366
+msgid "BuddyPress or WP SMS Pro is not enabled"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:377
+msgid "Parameter numbers is required"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-send.php:592
+msgid "Successfully sent SMS!"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:166
+msgid "Settings retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:186
+msgid "Section settings retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:203
+msgid "No settings data provided"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:232
+msgid "Validation failed"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:296
+msgid "Settings saved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:432
+#: resources/react/src/components/layout/Sidebar.jsx:90
+msgid "Gateway not configured"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:453
+msgid "Gateway connection successful"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:855
+msgid "This field is required"
+msgstr ""
+
+#. translators: %d: minimum number of characters required
+#: includes/api/v1/class-wpsms-api-settings.php:870
+#, php-format
+msgid "Value must be at least %d characters"
+msgstr ""
+
+#. translators: %d: maximum number of characters allowed
+#: includes/api/v1/class-wpsms-api-settings.php:878
+#, php-format
+msgid "Value must not exceed %d characters"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:887
+msgid "Value does not match the required format"
+msgstr ""
+
+#. translators: %s: minimum value allowed
+#: includes/api/v1/class-wpsms-api-settings.php:899
+#, php-format
+msgid "Value must be at least %s"
+msgstr ""
+
+#. translators: %s: maximum value allowed
+#: includes/api/v1/class-wpsms-api-settings.php:907
+#, php-format
+msgid "Value must not exceed %s"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:921
+msgid "Invalid email address"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:943
+msgid "Gateway registry retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:961
+#: includes/api/v1/class-wpsms-api-settings.php:998
+msgid "Gateway capabilities retrieved"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:1032
+msgid "Invalid gateway selected"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:1047
+msgid "Invalid phone number format"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:1062
+msgid "Invalid URL format"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:1068
+msgid "URL must use http or https protocol"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:1089
+msgid "Wizard status retrieved"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-settings.php:1111
+msgid "Wizard marked as complete"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:376
+msgid "Subscribers retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:403
+#: includes/api/v1/class-wpsms-api-subscribers.php:505
+#: includes/api/v1/class-wpsms-api-subscribers.php:569
+msgid "Subscriber not found"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:408
+msgid "Subscriber retrieved successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:463
+msgid "Subscriber already exists in all selected groups"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:466
+#: includes/api/v1/class-wpsms-api-subscribers.php:491
+msgid "Subscriber created successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:487
+msgid "Failed to create subscriber"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:532
+msgid "A subscriber with this phone number already exists"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:557
+#: resources/react/src/pages/Subscribers.jsx:123
+msgid "Subscriber updated successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:579
+msgid "Failed to delete subscriber"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:582
+#: resources/react/src/pages/Subscribers.jsx:101
+#: resources/react/src/pages/Subscribers.jsx:132
+msgid "Subscriber deleted successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:635
+msgid "Group ID is required for move action"
+msgstr ""
+
+#. translators: %d: number of subscribers updated
+#: includes/api/v1/class-wpsms-api-subscribers.php:649
+#, php-format
+msgid "%d subscriber(s) updated successfully"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:724
+msgid "No file uploaded"
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:739
+msgid "Invalid file type. Please upload a CSV file."
+msgstr ""
+
+#: includes/api/v1/class-wpsms-api-subscribers.php:745
+msgid "Failed to read uploaded file"
+msgstr ""
+
+#. translators: %d: row number in the CSV import file
+#: includes/api/v1/class-wpsms-api-subscribers.php:802
+#, php-format
+msgid "Row %d: Mobile number is required"
+msgstr ""
+
+#. translators: %1$d: row number in the CSV import file, %2$s: error message
+#: includes/api/v1/class-wpsms-api-subscribers.php:813
+#, php-format
+msgid "Row %1$d: %2$s"
+msgstr ""
+
+#. translators: %d: row number in the CSV import file
+#: includes/api/v1/class-wpsms-api-subscribers.php:826
+#, php-format
+msgid "Row %d: Subscriber already exists"
+msgstr ""
+
+#. translators: %d: row number in the CSV import file
+#: includes/api/v1/class-wpsms-api-subscribers.php:839
+#, php-format
+msgid "Row %d: Failed to add subscriber"
+msgstr ""
+
+#. translators: %1$d: number of subscribers imported, %2$d: number of subscribers skipped
+#: includes/api/v1/class-wpsms-api-subscribers.php:848
+#, php-format
+msgid "Import completed: %1$d imported, %2$d skipped"
+msgstr ""
+
+#: includes/class-wpsms-gateway.php:320
+#: resources/react/src/components/layout/Sidebar.jsx:159
+#: resources/react/src/pages/SendSms.jsx:280
+msgid "Credit"
+msgstr ""
+
+#: includes/class-wpsms-gateway.php:533
+#: includes/class-wpsms-gateway.php:560
+#: src/Admin/LicenseManagement/Plugin/PluginDecorator.php:157
+#: src/Admin/SiteHealthInfo.php:107
+#: resources/react/src/lib/tableColumns.jsx:65
+#: resources/react/src/lib/tableColumns.jsx:323
+#: resources/react/src/lib/tableColumns.jsx:325
+#: resources/react/src/pages/Integrations.jsx:27
+#: resources/react/src/pages/Privacy.jsx:171
+#: resources/react/src/pages/Subscribers.jsx:426
+#: resources/react/src/pages/Subscribers.jsx:677
+#: resources/react/src/pages/Subscribers.jsx:737
+msgid "Inactive"
+msgstr ""
+
+#. translators: %1$s: Helpful tip, %2$s: Gateway documentation URL
+#: includes/class-wpsms-gateway.php:585
+#, php-format
+msgid "%1$s <a href=\"%2$s\" target=\"_blank\">Documentation</a>"
+msgstr ""
+
+#. translators: %1$s: Helpful tip, %2$s: Gateway documentation URL
+#: includes/class-wpsms-gateway.php:585
+#: src/Admin/SiteHealthInfo.php:52
+msgid "N/A"
+msgstr ""
+
+#: includes/class-wpsms-gateway.php:611
+#: includes/class-wpsms-gateway.php:633
+#: includes/class-wpsms-gateway.php:653
+msgid "Available"
+msgstr ""
+
+#: includes/class-wpsms-gateway.php:617
+#: includes/class-wpsms-gateway.php:639
+#: includes/class-wpsms-gateway.php:659
+msgid "Not Available"
+msgstr ""
+
+#. translators: %s: Site name
+#: includes/class-wpsms-gateway.php:1068
+#, php-format
+msgid "%s - SMS Sending Alert"
+msgstr ""
+
+#: includes/class-wpsms-gateway.php:1076
+msgid "SMS Delivery Issue"
+msgstr ""
+
+#: includes/class-wpsms-gateway.php:1080
+msgid "Check SMS gateway configuration"
+msgstr ""
+
+#. translators: %1$s: URL to gateway settings page
+#: includes/class-wpsms-gateway.php:1134
+#, php-format
+msgid "SMS gateway setup requires your attention. <a href=\"%1$s\">Review and update your gateway settings</a> to ensure SMS messages are sent successfully."
+msgstr ""
+
+#: includes/class-wpsms-integrations.php:33
+#: src/Services/Formidable/FormidableManager.php:69
+msgid "SMS Notifications"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:95
+#: src/Controller/AjaxControllerAbstract.php:51
+msgid "Access denied."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:95
+#: includes/class-wpsms-newsletter.php:129
+#: includes/class-wpsms-newsletter.php:137
+msgid "SMS newsletter"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:96
+#: includes/class-wpsms-newsletter.php:130
+#: includes/class-wpsms-newsletter.php:138
+msgid "Home page"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:198
+msgid "Subscriber successfully added."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:200
+msgid "Failed to add subscriber, please deactivate and then activate WP SMS and then try again."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:311
+msgid "Mobile number is required!"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:336
+msgid "The mobile number does not exist in the specified group(s)!"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:346
+msgid "Successfully canceled the subscription!"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:366
+msgid "The fields must be valued."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:401
+msgid "Subscriber successfully updated."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:403
+msgid "No change has been occurred."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:509
+msgid "Name is empty!"
+msgstr ""
+
+#. translators: 1: Group name
+#. translators: %s: Group name
+#: includes/class-wpsms-newsletter.php:521
+#: includes/class-wpsms-newsletter.php:585
+#: includes/class-wpsms-newsletter.php:615
+#, php-format
+msgid "Group Name \"%s\" exists!"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:550
+msgid "Group successfully added."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:610
+msgid "Group successfully updated."
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:761
+msgid "Invalid group_id format!"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:837
+msgid "Invalid mobile number format!"
+msgstr ""
+
+#: includes/class-wpsms-newsletter.php:872
+#: src/Blocks/SendSmsBlock.php:54
+#: resources/react/src/pages/Subscribers.jsx:592
+#: resources/react/src/pages/Subscribers.jsx:595
+#: resources/react/src/pages/Subscribers.jsx:834
+#: resources/react/src/pages/Subscribers.jsx:837
+msgid "No Group"
+msgstr ""
+
+#. translators: %s: WordPress version number
+#: includes/class-wpsms-notifications.php:75
+#, php-format
+msgid "WordPress %s is available! Please update now"
+msgstr ""
+
+#: includes/class-wpsms-notifications.php:238
+msgid "SMS Notification"
+msgstr ""
+
+#: includes/functions.php:254
+#: includes/templates/subscribe-form.php:25
+#: resources/blocks/subscribe/edit.js:69
+#: resources/react/src/lib/tableColumns.jsx:278
+#: resources/react/src/pages/Subscribers.jsx:373
+#: resources/react/src/pages/Subscribers.jsx:917
+msgid "Phone Number"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-adpdigital.php:96
+#: includes/gateways/class-wpsms-gateway-adspanel.php:118
+#: includes/gateways/class-wpsms-gateway-afe.php:109
+#: includes/gateways/class-wpsms-gateway-bulutfon.php:76
+#: includes/gateways/class-wpsms-gateway-comilio.php:111
+#: includes/gateways/class-wpsms-gateway-firstpayamak.php:93
+#: includes/gateways/class-wpsms-gateway-fortytwo.php:128
+#: includes/gateways/class-wpsms-gateway-hirosms.php:106
+#: includes/gateways/class-wpsms-gateway-hostiran.php:129
+#: includes/gateways/class-wpsms-gateway-iransmspanel.php:152
+#: includes/gateways/class-wpsms-gateway-jahanpayamak.php:115
+#: includes/gateways/class-wpsms-gateway-jawalbsms.php:110
+#: includes/gateways/class-wpsms-gateway-novin1sms.php:98
+#: includes/gateways/class-wpsms-gateway-onlinepanel.php:110
+#: includes/gateways/class-wpsms-gateway-payamakaria.php:104
+#: includes/gateways/class-wpsms-gateway-payamakpanel.php:104
+#: includes/gateways/class-wpsms-gateway-payamresan.php:94
+#: includes/gateways/class-wpsms-gateway-persiansms.php:105
+#: includes/gateways/class-wpsms-gateway-reachinteractive.php:169
+#: includes/gateways/class-wpsms-gateway-safasms.php:129
+#: includes/gateways/class-wpsms-gateway-shreesms.php:93
+#: includes/gateways/class-wpsms-gateway-sms77.php:94
+#: includes/gateways/class-wpsms-gateway-smsban.php:105
+#: includes/gateways/class-wpsms-gateway-smsbartar.php:95
+#: includes/gateways/class-wpsms-gateway-smsclick.php:103
+#: includes/gateways/class-wpsms-gateway-smsgatewaycenter.php:102
+#: includes/gateways/class-wpsms-gateway-smshosting.php:125
+#: includes/gateways/class-wpsms-gateway-smsline.php:95
+#: includes/gateways/class-wpsms-gateway-torpedos.php:123
+#: includes/gateways/class-wpsms-gateway-tripadasmsbox.php:119
+#: includes/gateways/class-wpsms-gateway-tsms.php:95
+#: includes/gateways/class-wpsms-gateway-zain.php:115
+msgid "Username and Password are required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-adspanel.php:33
+#: includes/gateways/class-wpsms-gateway-adspanel.php:113
+#: includes/gateways/class-wpsms-gateway-bandarsms.php:34
+#: includes/gateways/class-wpsms-gateway-bandarsms.php:110
+#: includes/gateways/class-wpsms-gateway-candoosms.php:26
+#: includes/gateways/class-wpsms-gateway-candoosms.php:113
+#: includes/gateways/class-wpsms-gateway-mdpanel.php:34
+#: includes/gateways/class-wpsms-gateway-mdpanel.php:110
+#: includes/gateways/class-wpsms-gateway-mydnspanel.php:33
+#: includes/gateways/class-wpsms-gateway-mydnspanel.php:113
+#: includes/gateways/class-wpsms-gateway-nasrpayam.php:34
+#: includes/gateways/class-wpsms-gateway-nasrpayam.php:110
+#: includes/gateways/class-wpsms-gateway-smshooshmand.php:34
+#: includes/gateways/class-wpsms-gateway-smshooshmand.php:109
+#: includes/gateways/class-wpsms-gateway-smsmelli.php:34
+#: includes/gateways/class-wpsms-gateway-smsmelli.php:101
+msgid "nusoap_client class does not exist. Please enable it in your server configuration."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-afe.php:113
+#: includes/gateways/class-wpsms-gateway-aradsms.php:106
+#: includes/gateways/class-wpsms-gateway-arkapayamak.php:114
+#: includes/gateways/class-wpsms-gateway-bestit.php:121
+#: includes/gateways/class-wpsms-gateway-chapargah.php:108
+#: includes/gateways/class-wpsms-gateway-farapayamak.php:108
+#: includes/gateways/class-wpsms-gateway-firstpayamak.php:97
+#: includes/gateways/class-wpsms-gateway-hirosms.php:110
+#: includes/gateways/class-wpsms-gateway-idehpayam.php:110
+#: includes/gateways/class-wpsms-gateway-imencms.php:105
+#: includes/gateways/class-wpsms-gateway-iransmspanel.php:156
+#: includes/gateways/class-wpsms-gateway-iranspk.php:108
+#: includes/gateways/class-wpsms-gateway-jahanpayamak.php:119
+#: includes/gateways/class-wpsms-gateway-labsmobile.php:121
+#: includes/gateways/class-wpsms-gateway-loginpanel.php:109
+#: includes/gateways/class-wpsms-gateway-markazpayamak.php:108
+#: includes/gateways/class-wpsms-gateway-mediana.php:25
+#: includes/gateways/class-wpsms-gateway-novin1sms.php:102
+#: includes/gateways/class-wpsms-gateway-onlinepanel.php:114
+#: includes/gateways/class-wpsms-gateway-paaz.php:108
+#: includes/gateways/class-wpsms-gateway-parsasms.php:104
+#: includes/gateways/class-wpsms-gateway-parsgreen.php:121
+#: includes/gateways/class-wpsms-gateway-payamakaria.php:108
+#: includes/gateways/class-wpsms-gateway-payamakpanel.php:108
+#: includes/gateways/class-wpsms-gateway-payameroz.php:108
+#: includes/gateways/class-wpsms-gateway-persiansms.php:109
+#: includes/gateways/class-wpsms-gateway-rayansmspanel.php:108
+#: includes/gateways/class-wpsms-gateway-razpayamak.php:107
+#: includes/gateways/class-wpsms-gateway-smsban.php:109
+#: includes/gateways/class-wpsms-gateway-smsbartar.php:99
+#: includes/gateways/class-wpsms-gateway-smscall.php:98
+#: includes/gateways/class-wpsms-gateway-smsclick.php:107
+#: includes/gateways/class-wpsms-gateway-smsline.php:99
+#: includes/gateways/class-wpsms-gateway-smstoos.php:108
+#: includes/gateways/class-wpsms-gateway-ssmss.php:102
+#: includes/gateways/class-wpsms-gateway-textsms.php:102
+#: includes/gateways/class-wpsms-gateway-tsms.php:99
+#: includes/gateways/class-wpsms-gateway-websmscy.php:124
+#: includes/gateways/class-wpsms-gateway-_0098sms.php:111
+msgid "Class SoapClient not found. please enable php_soap in your php."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-afilnet.php:117
+#: includes/gateways/class-wpsms-gateway-aradsms.php:102
+#: includes/gateways/class-wpsms-gateway-arkapayamak.php:110
+#: includes/gateways/class-wpsms-gateway-aruba.php:110
+#: includes/gateways/class-wpsms-gateway-asanak.php:102
+#: includes/gateways/class-wpsms-gateway-bandarsms.php:115
+#: includes/gateways/class-wpsms-gateway-bestit.php:117
+#: includes/gateways/class-wpsms-gateway-callifony.php:108
+#: includes/gateways/class-wpsms-gateway-candoosms.php:118
+#: includes/gateways/class-wpsms-gateway-chapargah.php:104
+#: includes/gateways/class-wpsms-gateway-eazismspro.php:133
+#: includes/gateways/class-wpsms-gateway-eurosms.php:145
+#: includes/gateways/class-wpsms-gateway-experttexting.php:156
+#: includes/gateways/class-wpsms-gateway-farapayamak.php:104
+#: includes/gateways/class-wpsms-gateway-idehpayam.php:106
+#: includes/gateways/class-wpsms-gateway-imencms.php:101
+#: includes/gateways/class-wpsms-gateway-instantalerts.php:98
+#: includes/gateways/class-wpsms-gateway-iranspk.php:104
+#: includes/gateways/class-wpsms-gateway-ismsie.php:95
+#: includes/gateways/class-wpsms-gateway-labsmobile.php:117
+#: includes/gateways/class-wpsms-gateway-loginpanel.php:105
+#: includes/gateways/class-wpsms-gateway-markazpayamak.php:104
+#: includes/gateways/class-wpsms-gateway-mdpanel.php:115
+#: includes/gateways/class-wpsms-gateway-mediana.php:109
+#: includes/gateways/class-wpsms-gateway-mensatek.php:100
+#: includes/gateways/class-wpsms-gateway-mobiledotnet.php:108
+#: includes/gateways/class-wpsms-gateway-mtarget.php:131
+#: includes/gateways/class-wpsms-gateway-mydnspanel.php:118
+#: includes/gateways/class-wpsms-gateway-nasrpayam.php:115
+#: includes/gateways/class-wpsms-gateway-paaz.php:104
+#: includes/gateways/class-wpsms-gateway-parsasms.php:100
+#: includes/gateways/class-wpsms-gateway-parsgreen.php:117
+#: includes/gateways/class-wpsms-gateway-payameroz.php:104
+#: includes/gateways/class-wpsms-gateway-rayansmspanel.php:104
+#: includes/gateways/class-wpsms-gateway-raygansms.php:114
+#: includes/gateways/class-wpsms-gateway-razpayamak.php:103
+#: includes/gateways/class-wpsms-gateway-smsc.php:112
+#: includes/gateways/class-wpsms-gateway-smscall.php:94
+#: includes/gateways/class-wpsms-gateway-smsgatewayat.php:94
+#: includes/gateways/class-wpsms-gateway-smshooshmand.php:114
+#: includes/gateways/class-wpsms-gateway-smsmelli.php:106
+#: includes/gateways/class-wpsms-gateway-smssolutions.php:136
+#: includes/gateways/class-wpsms-gateway-smstoos.php:104
+#: includes/gateways/class-wpsms-gateway-sonoratecnologia.php:119
+#: includes/gateways/class-wpsms-gateway-spirius.php:107
+#: includes/gateways/class-wpsms-gateway-ssmss.php:98
+#: includes/gateways/class-wpsms-gateway-sunwaysms.php:131
+#: includes/gateways/class-wpsms-gateway-textanywhere.php:229
+#: includes/gateways/class-wpsms-gateway-textsms.php:98
+#: includes/gateways/class-wpsms-gateway-unisender.php:115
+#: includes/gateways/class-wpsms-gateway-websmscy.php:120
+#: includes/gateways/class-wpsms-gateway-_0098sms.php:107
+msgid "API username or API password is not entered."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-afilnet.php:131
+msgid "Server API Unavailable"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-africastalking.php:122
+msgid "Username and API key are required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-aobox.php:129
+#: includes/gateways/class-wpsms-gateway-hostpinnacle.php:135
+msgid "The username/password for this gateway is not set."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-aspsms.php:134
+#: includes/gateways/class-wpsms-gateway-cellsynt.php:140
+msgid "The username/password for this gateway is not set"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-bulkgate.php:165
+msgid "Application id and Application token for this gateway are require."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-cellsynt.php:41
+msgid "Originator Type"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-cellsynt.php:42
+msgid "Please select originator type."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-cellsynt.php:45
+msgid "Alpha"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-cellsynt.php:46
+msgid "Numeric"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-cellsynt.php:47
+msgid "Shortcode"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-cheapglobalsms.php:141
+#: includes/gateways/class-wpsms-gateway-jusibe.php:117
+#: includes/gateways/class-wpsms-gateway-onewaysms.php:160
+#: includes/gateways/class-wpsms-gateway-_ebulksms.php:116
+msgid "The Username/Password for this gateway is not set"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-cpsms.php:114
+#: includes/gateways/class-wpsms-gateway-suresms.php:103
+#: includes/gateways/class-wpsms-gateway-verimor.php:104
+msgid "The Username/API Key for this gateway is not set"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:29
+msgid "Use this gateway to integrate any HTTP-based SMS provider. Configure the endpoint and parameters below."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:33
+msgid "Send SMS API URL"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:34
+msgid "Enter the Send SMS URL for the SMS gateway API where the SMS requests will be sent. This URL is provided by the SMS gateway service."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:38
+msgid "HTTP Headers"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:39
+msgid "One <code>Header-Name: value</code> per line. Example: <code>Content-Type: application/json</code>, <code>Authorization: Bearer xxx</code>"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:44
+msgid "Body Format"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:45
+msgid "Choose how the request body is built. Use Key-Value for simple flat APIs, or Raw JSON for Postman-style payloads with nested objects or arrays."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:54
+msgid "HTTP Parameters"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:55
+msgid "One <code>key:value</code> per line. Placeholders: <code>{from}</code>, <code>{to}</code>, <code>{message}</code>. Wrap a value in square brackets to send it as a JSON array. Example: <code>to:{to}</code>, <code>message:{message}</code>, <code>recipients:[{to}]</code>"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:61
+msgid "Request Body (JSON)"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:62
+msgid ""
+"Paste the full JSON payload, just like in Postman. Placeholders <code>{from}</code>, <code>{to}</code>, <code>{message}</code>, <code>{recipients}</code> are replaced at send time. Any other keys are sent as-is, so you can add provider-specific fields (sender, route, callback URL, etc.). Example:<pre>{\n"
+"  \"body\": \"{message}\",\n"
+"  \"originator\": \"{from}\",\n"
+"  \"recipients\": [{recipients}],\n"
+"  \"route\": \"business\",\n"
+"  \"reference\": \"wsms-order-42\"\n"
+"}</pre>"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:75
+msgid "Send HTTP Parameters as a JSON POST body, or as URL query parameters."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:86
+msgid "Select 'Yes' to encode the SMS message content to ensure compatibility with the gateway. Encoding may be necessary for special characters or binary data"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:95
+#: includes/gateways/class-wpsms-gateway-custom.php:96
+#: includes/gateways/class-wpsms-gateway-prosms.php:28
+#: includes/gateways/class-wpsms-gateway-prosms.php:29
+#: includes/gateways/class-wpsms-gateway-prosmsdk.php:28
+#: includes/gateways/class-wpsms-gateway-prosmsdk.php:29
+msgid "Sender Name"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-custom.php:226
+msgid "Please complete the send SMS API URL."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-deewan.php:134
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:145
+msgid "Username and password are required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-default.php:34
+msgid "The SMS gateway in the plugin is not configured yet."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-dexatel.php:104
+msgid "API key is not entered."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-directsend.php:152
+msgid "The Username/API key for this gateway is not set."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-farazsms.php:84
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:104
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:86
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:83
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:110
+#: includes/gateways/class-wpsms-gateway-sms.php:84
+msgid "Sender Number"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-farazsms.php:85
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:105
+#: includes/gateways/class-wpsms-gateway-sms.php:85
+msgid "e.g., 50002178584000"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-farazsms.php:86
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:106
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:88
+#: includes/gateways/class-wpsms-gateway-sms.php:86
+msgid "Number or sender ID shown on recipient’s device."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-farazsms.php:91
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:111
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:93
+#: includes/gateways/class-wpsms-gateway-sms.php:91
+msgid "Enter your gateway API key."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-farazsms.php:139
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:146
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:220
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:174
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:231
+#: includes/gateways/class-wpsms-gateway-sms.php:139
+msgid "API Key is required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-farazsms.php:167
+#: includes/gateways/class-wpsms-gateway-sms.php:168
+msgid "Failed to send SMS."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-farazsms.php:253
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:276
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:314
+#: includes/gateways/class-wpsms-gateway-sms.php:255
+msgid "Message does not contain valid template placeholders."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:27
+msgid "Enter number without country code."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:28
+msgid "For <b>DLT</b> messages, send variables and message id in this format: <b>var1|var2|message_id</b>. <br> For <b>DLT Manual</b> messages, send message and template id in the same way. e.g. <b>message|template_id</b>"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:33
+#: includes/gateways/class-wpsms-gateway-tubelightcommunications.php:47
+msgid "Route"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:34
+msgid "Please select SMS route."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:37
+msgid "DLT SMS"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:38
+msgid "DLT Manual SMS"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:39
+msgid "Quick SMS"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:45
+#: includes/gateways/class-wpsms-gateway-smsozone.php:30
+msgid "Enter API key of gateway."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:49
+#: includes/gateways/class-wpsms-gateway-smsozone.php:34
+msgid "Approved Sender ID"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:50
+#: includes/gateways/class-wpsms-gateway-smsozone.php:35
+msgid "Enter sender ID of gateway."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:55
+msgid "Entity ID"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-fast2sms.php:56
+msgid "Enter your Registered Entity ID."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:94
+msgid "API Type"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-ghasedak.php:195
+msgid "Gateway request failed."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-globalvoice.php:129
+msgid "Token is not entered."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:87
+msgid "e.g., 0018018949161"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:280
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:318
+msgid "Template ID is missing."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-kavenegar.php:362
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:514
+msgid "Invalid template response payload."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-liveall.php:125
+msgid "The API Token for this gateway is not set."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:68
+msgid "LogisticSMS uses your account Username and API Password to obtain an access token automatically. Enter the Username and API Password from your LogisticSMS panel, and set one of your approved sender lines as the Sender ID."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:74
+msgid "Your LogisticSMS account username."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:79
+msgid "Your LogisticSMS account password. It is used to obtain the API token automatically."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:84
+msgid "One of your approved LogisticSMS sender lines."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:102
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:165
+msgid "Username and API Password are required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:129
+msgid "Unexpected response from the LogisticSMS send endpoint."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:179
+msgid "Unexpected response from the LogisticSMS account endpoint."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-logisticsms.php:209
+msgid "Unexpected response from the LogisticSMS login endpoint."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-matinsms.php:67
+#: includes/gateways/class-wpsms-gateway-matinsms.php:108
+#: includes/gateways/class-wpsms-gateway-msegat.php:153
+#: includes/gateways/class-wpsms-gateway-nesssolution.php:116
+#: includes/gateways/class-wpsms-gateway-primotexto.php:152
+#: includes/gateways/class-wpsms-gateway-sabanovin.php:111
+#: includes/gateways/class-wpsms-gateway-smsbox.php:153
+#: includes/gateways/class-wpsms-gateway-_18sms.php:98
+msgid "The API Key for this gateway is not set"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:101
+msgid "Enter the API username provided by your SMS gateway."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:106
+msgid "Enter the API password provided by your SMS gateway."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:111
+msgid "Enter the sender number or sender ID registered with your SMS gateway."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:115
+msgid "Backup sender 1 (optional)"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:116
+msgid "Optional: support sender number used with Smart SMS."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:120
+msgid "Backup sender 2 (optional)"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:121
+msgid "Optional: secondary support sender used with Smart SMS."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:179
+#: includes/gateways/class-wpsms-gateway-smses.php:110
+msgid "API Username and API Password are required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:260
+msgid "Invalid response from SMS service."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:398
+msgid "نام کاربری یا رمز عبور اشتباه می باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:401
+msgid "اعتبار کافی نمی باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:404
+msgid "محدودیت در ارسال روزانه."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:407
+msgid "محدودیت در حجم ارسال."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:410
+msgid "شماره فرستنده معتبر نمی باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:413
+msgid "سامانه در حال بروزرسانی می باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:416
+msgid "متن حاوی کلمه فیلتر شده می باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:419
+msgid "ارسال از خطوط عمومی از طریق وب سرویس امکان پذیر نمی باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:422
+msgid "کاربر مورد نظر فعال نمی باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:425
+msgid "ارسال نشده."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:428
+msgid "مدارک کاربر کامل نمی باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:431
+msgid "متن حاوی لینک می باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:434
+msgid "ارسال به بیش از 1 شماره همراه بدون درج \"لغو11\" ممکن نیست."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:437
+msgid "شماره گیرنده ای یافت نشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:440
+msgid "متن پیامک خالی می باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:443
+msgid "شماره گیرنده نامعتبر است."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:446
+msgid "در REST به معنای وجود شماره در لیست سیاه مخابرات می‌باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:449
+msgid "در میان متغییر های ارسالی ، لینک وجود دارد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:452
+msgid "خطایی در شماره فرستنده رخ داده است با پشتیبانی تماس بگیرید."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:455
+msgid "خطای داخلی رخ داده است با پشتیبانی تماس بگیرید."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:458
+msgid "متن ارسالی باتوجه به متغیرهای مشخص شده در متن پیشفرض همخوانی ندارد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:461
+msgid "کد متن ارسالی صحیح نمی‌باشد و یا توسط مدیر سامانه تأیید نشده است."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:464
+msgid "خط ارسالی در سیستم تعریف نشده است، با پشتیبانی سامانه تماس بگیرید."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:467
+msgid "محدودیت تعداد شماره، محدودیت هربار ارسال یک شماره موبایل می‌باشد."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:470
+msgid "دسترسی برای استفاده از این وبسرویس غیرفعال است. با پشتیبانی تماس بگیرید."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-melipayamak.php:473
+msgid "خطای ناشناخته‌ای رخ داده است."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-msegat.php:148
+msgid "The Username for this gateway is not set"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-mtarget.php:32
+msgid "Number of the recipient with country code (+44...) or in international format (0044 ...)"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-octopush.php:34
+msgid "API Login"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-octopush.php:35
+msgid "Enter your API Login - Username (Email address)"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-octopush.php:40
+msgid "Enter your API KEY"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-octopush.php:45
+msgid "Enter Sender Name"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-octopush.php:130
+msgid "API Login or API Key is not set."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-oxemis.php:119
+msgid "The API Key and API Password are required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-prosms.php:22
+msgid "46*********"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-prosms.php:24
+#: includes/gateways/class-wpsms-gateway-prosmsdk.php:24
+msgid "Note: that you need to get every 'Sender Name' approved before you can use it as 'Sender Name'. You can do it by going to your gateway account then go to this path : Account setting > SENDER NAME > Add"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-prosms.php:33
+#: includes/gateways/class-wpsms-gateway-prosmsdk.php:33
+msgid "API Iey"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-prosms.php:112
+#: includes/gateways/class-wpsms-gateway-prosmsdk.php:111
+msgid "Api key for this gateway is required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-prosmsdk.php:22
+msgid "45*********"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-revesms.php:136
+msgid "The API Key/Secret Key for this gateway is not set."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-sendapp.php:111
+msgid "The API Key required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-sendappWhatsApp.php:95
+msgid "The API Key Key for this gateway is not set."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-signalads.php:117
+msgid "The API Key is required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-slinteractive.php:104
+msgid "API username or API Key is not entered."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smartsmsgateway.php:122
+msgid "The Username/Password for this gateway is not set."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsapi.php:123
+msgid "API Token is required."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:77
+msgid "API Base URL"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:82
+msgid "Select the base URL for the SMS Gateway API."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:86
+msgid "Username"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:87
+msgid "sms.es API username (System ID)."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:91
+msgid "Password"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:92
+msgid "sms.es API password."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:96
+#: resources/react/src/pages/SendSms.jsx:312
+#: resources/react/src/pages/SendSms.jsx:313
+msgid "Sender ID"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smses.php:97
+msgid "Alphanumeric or numeric sender (subject to local regulations)."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsgatewayhub.php:51
+#: includes/gateways/class-wpsms-gateway-smsozone.php:49
+msgid "SMS Channel"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsgatewayhub.php:52
+#: includes/gateways/class-wpsms-gateway-smsozone.php:50
+msgid "Please select SMS channel."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsgatewayhub.php:55
+#: includes/gateways/class-wpsms-gateway-smsozone.php:53
+msgid "Transactional"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsgatewayhub.php:56
+#: includes/gateways/class-wpsms-gateway-smsozone.php:54
+msgid "Promotional"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsglobal.php:146
+msgid "The API Key or API Secret for this gateway is not set"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsozone.php:39
+msgid "Registered DLT Template ID"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsozone.php:40
+msgid "Enter your Registered DLT Template ID."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsozone.php:44
+msgid "DLT Entity ID"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsozone.php:45
+msgid "Enter your Registered Entity ID. This field is optional."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-smsto.php:196
+msgid "Invalid response from SMS.to API"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-textanywhere.php:197
+msgid "Username and API password are required."
+msgstr ""
+
+#. translators: %s: Function name
+#: includes/gateways/class-wpsms-gateway-textanywhere.php:241
+#, php-format
+msgid "The <code>%s</code> function is not active in your server."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-textanywhere.php:324
+msgid "Invalid get token response "
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-tubelightcommunications.php:26
+msgid "<b>SMS Route</b>: Please follow this format in your messages: <pre>message|template_id</pre><br><b>WhatsApp Route</b>: Please follow this format in your messages: <pre>var1:var2:var3:var4|template_name</pre>"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-tubelightcommunications.php:51
+#: includes/templates/admin/fields/field-team-member-repeater.php:39
+#: includes/templates/admin/fields/field-team-member-repeater.php:83
+msgid "WhatsApp"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-tubelightcommunications.php:53
+msgid "Please select the route."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-uwaziimobile.php:127
+msgid "The username/password is not entered."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-uwaziimobile.php:133
+msgid "There is a problem with the username and password provided."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-websmscy.php:54
+#: includes/gateways/class-wpsms-gateway-websmscy.php:58
+#: includes/gateways/class-wpsms-gateway-websmscy.php:114
+msgid "The Websmscy class could not be found. Please ensure the Websmscy library or plugin is properly loaded."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:191
+msgid "Service Not Available or Down Temporary"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:195
+msgid "Invalid username/password."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:199
+msgid "Invalid server"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:203
+msgid "Username not provided."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:207
+msgid "Password not provided."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:212
+msgid "Insufficient Credits"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:216
+msgid "Invalid Sender ID"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:220
+msgid "Mobile number not provided."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:224
+msgid "Invalid mobile number"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:228
+msgid "Network not supported."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:232
+msgid "Invalid message."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:236
+msgid "Invalid quantity specified."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:240
+msgid "Network not supported"
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_1s2u.php:244
+msgid "Something's wrong. Please contact the SMS gateway provider support team."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_textplode.php:49
+msgid "Configure Textplode API Key and From Name."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_textplode.php:86
+msgid "Unknown API error."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_textplode.php:92
+msgid "Invalid response from gateway."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_textplode.php:116
+msgid "Please enter your API key."
+msgstr ""
+
+#: includes/gateways/class-wpsms-gateway-_textplode.php:131
+msgid "Unable to retrieve balance."
+msgstr ""
+
+#: includes/libraries/wp-background-processing/wp-background-process.php:658
+msgid "Every Minute"
+msgstr ""
+
+#. translators: %d: number of minutes
+#: includes/libraries/wp-background-processing/wp-background-process.php:661
+#, php-format
+msgid "Every %d Minutes"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:10
+#: resources/react/src/pages/CartAbandonment.jsx:393
+msgid "Sent SMS"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:21
+msgid "Time frame"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:22
+msgid "7D"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:23
+msgid "30D"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:24
+msgid "12M"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:25
+msgid "YTD"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:31
+#: includes/templates/email/partials/report-data.php:61
+#: includes/templates/email/partials/report-data.php:90
+#: includes/templates/email/partials/report-data.php:115
+#: src/Service/Assets/Handlers/AdminHandler.php:233
+#: src/Widget/Widgets/StatsWidget.php:147
+#: resources/react/src/pages/Outbox.jsx:370
+#: resources/react/src/pages/Scheduled.jsx:318
+#: resources/react/src/pages/Scheduled.jsx:926
+#: resources/react/src/pages/Subscribers.jsx:651
+#: resources/react/src/pages/TwoWayCommands.jsx:648
+#: resources/react/src/pages/TwoWayInbox.jsx:487
+msgid "Total"
+msgstr ""
+
+#: includes/templates/admin/dashboard-widget.php:36
+#: includes/templates/email/partials/report-data.php:111
+#: src/Widget/Widgets/StatsWidget.php:144
+#: resources/react/src/pages/TwoWayInbox.jsx:367
+#: resources/react/src/pages/TwoWayInbox.jsx:575
+#: resources/react/src/pages/TwoWayInbox.jsx:692
+msgid "Successful"
+msgstr ""
+
+#: includes/templates/admin/fields/field-resource-link-repeater.php:13
+#: includes/templates/admin/fields/field-resource-link-repeater.php:29
+msgid "Add titles and URLs for your resource links"
+msgstr ""
+
+#: includes/templates/admin/fields/field-resource-link-repeater.php:13
+#: includes/templates/admin/fields/field-resource-link-repeater.php:29
+#: src/Services/MessageButton/ChatBoxDecorator.php:161
+msgid "Troubleshooting Common Issues"
+msgstr ""
+
+#: includes/templates/admin/fields/field-resource-link-repeater.php:14
+#: includes/templates/admin/fields/field-resource-link-repeater.php:30
+msgid "Add titles and URLs for your resource links, e.g., 'FAQs' or 'Contact Us'"
+msgstr ""
+
+#: includes/templates/admin/fields/field-resource-link-repeater.php:17
+#: includes/templates/admin/fields/field-resource-link-repeater.php:33
+msgid "Chatbox link url"
+msgstr ""
+
+#: includes/templates/admin/fields/field-resource-link-repeater.php:20
+#: includes/templates/admin/fields/field-resource-link-repeater.php:36
+#: includes/templates/admin/fields/field-team-member-repeater.php:53
+#: includes/templates/admin/fields/field-team-member-repeater.php:97
+#: includes/templates/admin/fields/field-wc-status-repeater.php:39
+#: includes/templates/admin/fields/field-wc-status-repeater.php:70
+#: resources/react/src/components/shared/DeleteConfirmDialog.jsx:59
+#: resources/react/src/lib/tableColumns.jsx:233
+#: resources/react/src/lib/tableColumns.jsx:360
+#: resources/react/src/lib/tableColumns.jsx:459
+#: resources/react/src/lib/tableColumns.jsx:588
+#: resources/react/src/pages/CartAbandonment.jsx:157
+#: resources/react/src/pages/Groups.jsx:254
+#: resources/react/src/pages/SmsCampaigns.jsx:564
+#: resources/react/src/pages/Subscribers.jsx:470
+#: resources/react/src/pages/TwoWayCommands.jsx:320
+#: resources/react/src/pages/TwoWayInbox.jsx:413
+msgid "Delete"
+msgstr ""
+
+#: includes/templates/admin/fields/field-resource-link-repeater.php:43
+msgid "Add another link"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:18
+#: includes/templates/admin/fields/field-team-member-repeater.php:62
+#: includes/templates/admin/group-form.php:6
+#: includes/templates/admin/group-form.php:7
+#: includes/templates/admin/subscriber-form.php:10
+#: includes/templates/admin/subscriber-form.php:11
+#: resources/react/src/components/migration/PreviewStep.jsx:75
+#: resources/react/src/pages/MessageButton.jsx:677
+#: resources/react/src/pages/Subscribers.jsx:362
+#: resources/react/src/pages/TwoWayCommands.jsx:269
+msgid "Name"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:18
+#: includes/templates/admin/fields/field-team-member-repeater.php:62
+#: src/Services/MessageButton/ChatBoxDecorator.php:102
+#: resources/react/src/pages/MessageButton.jsx:315
+msgid "Emily Brown"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:19
+#: includes/templates/admin/fields/field-team-member-repeater.php:63
+msgid "Team member's name, e.g., 'Jane Doe'"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:22
+#: includes/templates/admin/fields/field-team-member-repeater.php:66
+#: resources/react/src/pages/MessageButton.jsx:678
+msgid "Role"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:22
+#: includes/templates/admin/fields/field-team-member-repeater.php:66
+#: src/Services/MessageButton/ChatBoxDecorator.php:105
+#: resources/react/src/pages/MessageButton.jsx:316
+msgid "Marketing Manager"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:23
+#: includes/templates/admin/fields/field-team-member-repeater.php:67
+msgid "Team member's department or role, e.g., 'Customer Support'"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:27
+#: includes/templates/admin/fields/field-team-member-repeater.php:71
+msgid "Photo"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:28
+#: includes/templates/admin/fields/field-team-member-repeater.php:72
+msgid "Upload"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:30
+#: includes/templates/admin/fields/field-team-member-repeater.php:74
+msgid "Upload team member's photo."
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:33
+#: includes/templates/admin/fields/field-team-member-repeater.php:77
+#: resources/react/src/pages/MessageButton.jsx:687
+msgid "Availability"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:33
+#: includes/templates/admin/fields/field-team-member-repeater.php:77
+#: src/Services/MessageButton/ChatBoxDecorator.php:108
+#: resources/react/src/pages/MessageButton.jsx:317
+msgid "Available 10AM-5PM PST"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:34
+#: includes/templates/admin/fields/field-team-member-repeater.php:78
+msgid "State team member's chat hours, e.g., 'Available 10AM-5PM PST.'"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:37
+#: includes/templates/admin/fields/field-team-member-repeater.php:38
+#: includes/templates/admin/fields/field-team-member-repeater.php:81
+#: includes/templates/admin/fields/field-team-member-repeater.php:82
+#: resources/react/src/pages/MessageButton.jsx:679
+msgid "Contact Type"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:40
+#: includes/templates/admin/fields/field-team-member-repeater.php:84
+#: resources/react/src/pages/MessageButton.jsx:683
+msgid "Phone Call"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:41
+#: includes/templates/admin/fields/field-team-member-repeater.php:85
+msgid "Facebook Messenger"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:42
+#: includes/templates/admin/fields/field-team-member-repeater.php:86
+msgid "Telegram"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:44
+#: includes/templates/admin/fields/field-team-member-repeater.php:88
+msgid "E-mail"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:46
+#: includes/templates/admin/fields/field-team-member-repeater.php:90
+msgid "Set visitor communication methods, e.g., WhatsApp, Email."
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:49
+#: includes/templates/admin/fields/field-team-member-repeater.php:93
+#: resources/react/src/pages/MessageButton.jsx:686
+msgid "Contact Value"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:49
+#: includes/templates/admin/fields/field-team-member-repeater.php:93
+msgid "+1122334455"
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:50
+#: includes/templates/admin/fields/field-team-member-repeater.php:94
+msgid "Provide contact details for the chosen method."
+msgstr ""
+
+#: includes/templates/admin/fields/field-team-member-repeater.php:104
+msgid "Add another member"
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:14
+#: includes/templates/admin/fields/field-wc-status-repeater.php:47
+msgid "Choose an order status"
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:15
+#: includes/templates/admin/fields/field-wc-status-repeater.php:25
+#: includes/templates/admin/fields/field-wc-status-repeater.php:48
+#: includes/templates/admin/fields/field-wc-status-repeater.php:58
+msgid "Please Choose"
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:21
+#: includes/templates/admin/fields/field-wc-status-repeater.php:54
+msgid "Please choose an order status"
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:24
+#: includes/templates/admin/fields/field-wc-status-repeater.php:57
+msgid "Select notify status"
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:29
+#: includes/templates/admin/fields/field-wc-status-repeater.php:62
+msgid "Please select notify status"
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:34
+#: includes/templates/admin/fields/field-wc-status-repeater.php:65
+msgid "Enter the contents of the SMS message"
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:35
+#: includes/templates/admin/fields/field-wc-status-repeater.php:66
+msgid "Enter the contents of the SMS message."
+msgstr ""
+
+#: includes/templates/admin/fields/field-wc-status-repeater.php:77
+msgid "Add another order status"
+msgstr ""
+
+#: includes/templates/admin/group-form.php:17
+#: includes/templates/admin/subscriber-form.php:71
+#: resources/react/src/pages/AddOns.jsx:184
+msgid "Update"
+msgstr ""
+
+#: includes/templates/admin/group-form.php:19
+#: includes/templates/admin/subscriber-form.php:47
+#: includes/templates/admin/subscriber-form.php:73
+#: resources/react/src/pages/Subscribers.jsx:612
+#: resources/react/src/pages/Subscribers.jsx:857
+msgid "Add"
+msgstr ""
+
+#: includes/templates/admin/notice.php:6
+#: views/components/notices/action-notice.php:8
+#: views/components/notices/simple-notice.php:6
+msgid "Dismiss this notice."
+msgstr ""
+
+#: includes/templates/admin/order-view-metabox.php:13
+#: includes/templates/admin/order-view-metabox.php:48
+#: includes/templates/send-sms-form.php:22
+#: includes/templates/send-sms-form.php:52
+#: resources/blocks/send-sms/edit.js:84
+#: resources/blocks/send-sms/edit.js:137
+msgid "Receiver"
+msgstr ""
+
+#: includes/templates/admin/order-view-metabox.php:23
+msgid "Write your SMS message here ..."
+msgstr ""
+
+#: includes/templates/admin/order-view-metabox.php:28
+msgid "Variables"
+msgstr ""
+
+#: includes/templates/admin/order-view-metabox.php:37
+#: includes/templates/send-sms-form.php:14
+#: includes/templates/send-sms-form.php:40
+#: src/Services/WooCommerce/OrderViewManager.php:27
+#: resources/blocks/send-sms/edit.js:115
+#: resources/react/src/lib/pageRegistry.js:67
+#: resources/react/src/lib/tableColumns.jsx:350
+#: resources/react/src/pages/Outbox.jsx:344
+msgid "Send SMS"
+msgstr ""
+
+#: includes/templates/admin/order-view-metabox.php:53
+msgid "Content"
+msgstr ""
+
+#: includes/templates/admin/order-view-metabox.php:57
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:153
+#: resources/react/src/pages/Groups.jsx:285
+#: resources/react/src/pages/Outbox.jsx:306
+#: resources/react/src/pages/Scheduled.jsx:266
+#: resources/react/src/pages/Scheduled.jsx:876
+#: resources/react/src/pages/Subscribers.jsx:539
+msgid "Try Again"
+msgstr ""
+
+#: includes/templates/admin/quick-reply.php:19
+#: includes/templates/meta-box.php:8
+#: resources/react/src/pages/Outbox.jsx:693
+#: resources/react/src/pages/Outbox.jsx:750
+#: resources/react/src/pages/Scheduled.jsx:596
+#: resources/react/src/pages/Scheduled.jsx:1177
+msgid "To"
+msgstr ""
+
+#: includes/templates/admin/quick-reply.php:34
+#: resources/react/src/pages/TwoWayInbox.jsx:408
+#: resources/react/src/pages/TwoWayInbox.jsx:727
+msgid "Reply"
+msgstr ""
+
+#: includes/templates/admin/subscriber-form.php:16
+#: includes/templates/mobile-field.php:4
+#: src/User/MobileFieldHandler/WordPressMobileFieldHandler.php:55
+msgid "Mobile"
+msgstr ""
+
+#: includes/templates/admin/subscriber-form.php:25
+#: includes/templates/admin/subscriber-form.php:45
+#: includes/templates/email/partials/report-data.php:72
+#: resources/react/src/lib/tableColumns.jsx:294
+#: resources/react/src/pages/Subscribers.jsx:384
+#: resources/react/src/pages/Subscribers.jsx:936
+msgid "Group"
+msgstr ""
+
+#: includes/templates/admin/subscriber-form.php:32
+#: resources/react/src/pages/Notifications.jsx:150
+#: resources/react/src/pages/Subscribers.jsx:591
+#: resources/react/src/pages/Subscribers.jsx:833
+#: resources/react/src/pages/Subscribers.jsx:1100
+msgid "Select group"
+msgstr ""
+
+#: includes/templates/admin/subscriber-form.php:46
+msgid "There is no group!"
+msgstr ""
+
+#: includes/templates/admin/subscriber-form.php:58
+#: includes/templates/admin/subscriber-form.php:61
+#: resources/react/src/lib/tableColumns.jsx:387
+msgid "Deactivate"
+msgstr ""
+
+#: includes/templates/chatbox.php:18
+msgid "Chat widget"
+msgstr ""
+
+#: includes/templates/chatbox.php:45
+#: includes/templates/chatbox.php:46
+#: src/Service/Assets/Handlers/AdminHandler.php:264
+#: resources/react/src/components/migration/DoneStep.jsx:154
+#: resources/react/src/components/migration/ReviewStep.jsx:255
+#: resources/react/src/pages/Outbox.jsx:665
+#: resources/react/src/pages/Scheduled.jsx:572
+#: resources/react/src/pages/Scheduled.jsx:1159
+#: resources/react/src/pages/SmsCampaigns.jsx:1012
+#: resources/react/src/pages/SmsCampaigns.jsx:1159
+#: resources/react/src/pages/Subscribers.jsx:1129
+#: resources/react/src/pages/TwoWayInbox.jsx:720
+msgid "Close"
+msgstr ""
+
+#: includes/templates/chatbox.php:120
+msgid "Powered By"
+msgstr ""
+
+#: includes/templates/chatbox.php:121
+msgid "WSMS"
+msgstr ""
+
+#: includes/templates/email/default.php:30
+msgid "Hello,"
+msgstr ""
+
+#: includes/templates/email/default.php:32
+msgid "Best regards,"
+msgstr ""
+
+#: includes/templates/email/partials/footer-suggestion.php:5
+msgid "Upgrade to WP SMS Pro"
+msgstr ""
+
+#: includes/templates/email/partials/footer-suggestion.php:7
+msgid "Buy Now "
+msgstr ""
+
+#: includes/templates/email/partials/footer-suggestion.php:11
+msgid "Get more features and better performance with WP SMS All-In-One"
+msgstr ""
+
+#. translators: %1$s: Start date, %2$s: End date
+#: includes/templates/email/partials/report-data.php:7
+#, php-format
+msgid "From %1$s to %2$s"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:10
+msgid "At a glance"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:17
+#: includes/templates/email/partials/report-data.php:57
+msgid "Successful SMS"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:22
+#: includes/templates/email/partials/report-data.php:53
+msgid "Failed SMS"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:29
+msgid "New Active Subscribers SMS"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:34
+msgid "New Deactive Subscribers"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:43
+msgid "SMS Delivery Report"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:47
+#: includes/templates/email/partials/report-data.php:102
+msgid "Count"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:68
+msgid "Subscription Report"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:73
+msgid "Deactive"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:97
+msgid "Login With SMS Report"
+msgstr ""
+
+#: includes/templates/email/partials/report-data.php:101
+msgid "Type"
+msgstr ""
+
+#: includes/templates/email/partials/sms-delivery-issue.php:2
+msgid "WP SMS encountered an issue while sending SMS messages to the following numbers:"
+msgstr ""
+
+#: includes/templates/email/partials/sms-delivery-issue.php:5
+msgid "SMS Content"
+msgstr ""
+
+#: includes/templates/email/partials/sms-delivery-issue.php:8
+#: resources/react/src/pages/Gateway.jsx:777
+msgid "API Response"
+msgstr ""
+
+#: includes/templates/email/partials/sms-delivery-issue.php:11
+msgid "To address this issue, please verify the SMS configuration in the WP SMS settings page. Ensure that the credentials are correct, and you have entered the recipient numbers accurately, with or without the country code."
+msgstr ""
+
+#: includes/templates/formidable/formidable-form.php:11
+#: includes/templates/wpcf7-form.php:19
+#: resources/react/src/components/shared/RecipientSelector.jsx:14
+msgid "Numbers"
+msgstr ""
+
+#: includes/templates/formidable/formidable-form.php:14
+msgid "<b>Note:</b> When sending multiple numbers, please separate them with a comma. for example: 10000000001, 10000000002."
+msgstr ""
+
+#: includes/templates/formidable/formidable-form.php:20
+#: includes/templates/formidable/formidable-form.php:57
+#: includes/templates/meta-box.php:80
+#: includes/templates/wpcf7-form.php:50
+#: includes/templates/wpcf7-form.php:74
+#: src/Services/Forminator/ForminatorManager.php:66
+#: src/Services/Forminator/ForminatorManager.php:90
+#: resources/react/src/pages/Integrations.jsx:155
+#: resources/react/src/pages/Integrations.jsx:162
+#: resources/react/src/pages/Integrations.jsx:216
+#: resources/react/src/pages/Integrations.jsx:223
+#: resources/react/src/pages/Integrations.jsx:333
+#: resources/react/src/pages/Integrations.jsx:340
+#: resources/react/src/pages/Integrations.jsx:394
+#: resources/react/src/pages/Integrations.jsx:401
+#: resources/react/src/pages/Integrations.jsx:512
+#: resources/react/src/pages/Integrations.jsx:519
+#: resources/react/src/pages/Integrations.jsx:573
+#: resources/react/src/pages/Integrations.jsx:580
+#: resources/react/src/pages/Integrations.jsx:688
+#: resources/react/src/pages/Integrations.jsx:695
+#: resources/react/src/pages/Integrations.jsx:749
+#: resources/react/src/pages/Integrations.jsx:756
+msgid "Message body"
+msgstr ""
+
+#: includes/templates/formidable/formidable-form.php:36
+#: includes/templates/wpcf7-form.php:61
+msgid "Send to form"
+msgstr ""
+
+#: includes/templates/formidable/formidable-form.php:37
+#: includes/templates/wpcf7-form.php:62
+msgid "After submitting the form, you have the option to send an SMS message to the specified field:"
+msgstr ""
+
+#: includes/templates/formidable/formidable-form.php:40
+#: includes/templates/wpcf7-form.php:65
+msgid "Send to field"
+msgstr ""
+
+#: includes/templates/formidable/formidable-form.php:75
+msgid "Submit"
+msgstr ""
+
+#: includes/templates/meta-box.php:11
+msgid "Please select"
+msgstr ""
+
+#: includes/templates/meta-box.php:17
+#: includes/templates/meta-box.php:42
+msgid "Number(s)"
+msgstr ""
+
+#: includes/templates/meta-box.php:20
+msgid "WordPress Users"
+msgstr ""
+
+#: includes/templates/meta-box.php:26
+msgid "Subscribe group"
+msgstr ""
+
+#. translators: %s: Number of active subscribers
+#: includes/templates/meta-box.php:31
+#, php-format
+msgid "All (%s subscribers active)"
+msgstr ""
+
+#: includes/templates/meta-box.php:43
+msgid "Separate numbers with commas"
+msgstr ""
+
+#: includes/templates/meta-box.php:50
+msgid "Specific roles"
+msgstr ""
+
+#: includes/templates/meta-box.php:52
+msgid "Please select the Role"
+msgstr ""
+
+#: includes/templates/meta-box.php:67
+msgid " Users have mobile number."
+msgstr ""
+
+#: includes/templates/meta-box.php:84
+msgid "Short codes"
+msgstr ""
+
+#: includes/templates/mobile-field-register.php:3
+#: src/Blocks/WooMobileField.php:22
+#: src/Blocks/WooMobileField.php:23
+#: src/User/MobileFieldHandler/WooCommerceAddMobileFieldHandler.php:125
+#: src/User/MobileFieldHandler/WooCommerceAddMobileFieldHandler.php:143
+#: src/User/MobileFieldHandler/WooCommerceAddMobileFieldHandler.php:175
+#: resources/react/src/pages/SmsCampaigns.jsx:1112
+msgid "Mobile Number"
+msgstr ""
+
+#: includes/templates/mobile-field.php:7
+msgid "User mobile number."
+msgstr ""
+
+#: includes/templates/send-sms-form.php:8
+msgid "Send SMS Messages from Your Website"
+msgstr ""
+
+#: includes/templates/send-sms-form.php:9
+msgid "Give your website visitors the power to send SMS messages directly from your site."
+msgstr ""
+
+#: includes/templates/send-sms-form.php:10
+#: resources/react/src/pages/Overview.jsx:371
+msgid "Upgrade to WSMS Pro"
+msgstr ""
+
+#: includes/templates/send-sms-form.php:18
+#: includes/templates/send-sms-form.php:46
+msgid "Write your message content"
+msgstr ""
+
+#: includes/templates/send-sms-form.php:23
+#: resources/react/src/components/shared/RecipientSelector.jsx:580
+#: resources/react/src/pages/Privacy.jsx:272
+#: resources/react/src/pages/Subscribers.jsx:575
+#: resources/react/src/pages/Subscribers.jsx:576
+#: resources/react/src/pages/Subscribers.jsx:817
+#: resources/react/src/pages/Subscribers.jsx:818
+#: resources/react/src/pages/Subscribers.jsx:922
+msgid "Phone number"
+msgstr ""
+
+#: includes/templates/send-sms-form.php:26
+#: includes/templates/send-sms-form.php:59
+#: resources/blocks/send-sms/edit.js:141
+msgid "Send Message"
+msgstr ""
+
+#: includes/templates/send-sms-form.php:47
+msgid "Max remaining characters: "
+msgstr ""
+
+#: includes/templates/subscribe-form.php:12
+#: src/Shortcode/SubscriberShortcode.php:19
+msgid "Subscribe SMS"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:20
+#: resources/blocks/subscribe/edit.js:67
+msgid "Your Name"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:21
+msgid "Full Name"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:33
+msgid "Select the Groups"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:44
+msgid "Select a Group"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:46
+msgid "Please select the group"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:69
+#: includes/templates/subscribe-form.php:70
+#: includes/templates/subscribe-form.php:89
+#: src/Service/Assets/Handlers/FrontendHandler.php:67
+#: resources/blocks/subscribe/edit.js:49
+#: resources/blocks/subscribe/edit.js:71
+msgid "Subscribe"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:74
+#: includes/templates/subscribe-form.php:75
+msgid "Unsubscribe"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:82
+msgid "I agree to receive SMS based on my data"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:98
+#: includes/templates/subscribe-form.php:99
+msgid "Activation code"
+msgstr ""
+
+#: includes/templates/subscribe-form.php:101
+#: src/Service/Assets/Handlers/FrontendHandler.php:68
+#: resources/react/src/lib/tableColumns.jsx:382
+#: resources/react/src/pages/AddOns.jsx:186
+msgid "Activate"
+msgstr ""
+
+#: includes/templates/widget.php:8
+#: resources/blocks/send-sms/edit.js:127
+#: resources/blocks/subscribe/edit.js:61
+msgid "Description"
+msgstr ""
+
+#: includes/templates/widget.php:9
+msgid "HTML code is valid."
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:3
+msgid "SMS Recipient"
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:5
+msgid "After submitting the form you can send an SMS message to numbers or subscribers' group"
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:9
+#: resources/react/src/pages/Outbox.jsx:592
+#: resources/react/src/pages/Scheduled.jsx:511
+#: resources/react/src/pages/SendSms.jsx:386
+msgid "Recipients"
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:12
+msgid "Number"
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:13
+#: includes/templates/wpcf7-form.php:27
+#: resources/blocks/send-sms/edit.js:98
+#: resources/react/src/pages/Notifications.jsx:147
+msgid "Subscriber Group"
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:22
+#: includes/templates/wpcf7-form.php:45
+#: includes/templates/wpcf7-form.php:53
+#: includes/templates/wpcf7-form.php:69
+#: includes/templates/wpcf7-form.php:78
+msgid "Note: "
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:22
+msgid "When sending multiple numbers, please separate them with a comma. for example: 10000000001, 10000000002."
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:30
+msgid "Please select the Group"
+msgstr ""
+
+#. translators: %s: Group name
+#: includes/templates/wpcf7-form.php:37
+#, php-format
+msgid "Group %s"
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:45
+msgid "Multiple groups can be chosen."
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:53
+#: includes/templates/wpcf7-form.php:69
+#: includes/templates/wpcf7-form.php:78
+msgid "Use %% Instead of [], for example: "
+msgstr ""
+
+#: includes/templates/wpcf7-form.php:54
+#: includes/templates/wpcf7-form.php:79
+msgid "You can also use the following contact form 7 tags in the message body →"
+msgstr ""
+
+#: src/Admin/AjaxOptionUpdater.php:42
+msgid "You are not allowed to update settings."
+msgstr ""
+
+#: src/Admin/AjaxOptionUpdater.php:56
+msgid "Update option success."
+msgstr ""
+
+#: src/Admin/AnonymizedUsageData/AnonymizedUsageDataManager.php:39
+msgid "Every 2 Months"
+msgstr ""
+
+#: src/Admin/Dashboard.php:293
+msgid "Launch Setup Wizard"
+msgstr ""
+
+#: src/Admin/Dashboard.php:334
+#: views/components/objects/share-anonymous-notice.php:18
+msgid "Help us improve by sharing anonymous usage data. No personal or sensitive information is collected."
+msgstr ""
+
+#: src/Admin/Dashboard.php:335
+#: views/components/objects/share-anonymous-notice.php:17
+msgid "Help Us Improve WSMS!"
+msgstr ""
+
+#: src/Admin/Dashboard.php:342
+#: views/components/objects/share-anonymous-notice.php:25
+msgid "Enable Share Anonymous Data"
+msgstr ""
+
+#: src/Admin/Dashboard.php:348
+#: views/components/objects/share-anonymous-notice.php:21
+#: resources/react/src/pages/CartAbandonment.jsx:307
+#: resources/react/src/pages/Overview.jsx:379
+#: resources/react/src/pages/Scheduled.jsx:1320
+#: resources/react/src/pages/SmsCampaigns.jsx:761
+#: resources/react/src/pages/TwoWayCommands.jsx:345
+#: resources/react/src/pages/TwoWayInbox.jsx:454
+#: resources/react/src/pages/TwoWaySettings.jsx:175
+msgid "Learn More"
+msgstr ""
+
+#: src/Admin/Dashboard.php:373
+msgid "Set your default country so we know how to interpret phone numbers without an international prefix. Without it, locally-formatted numbers cannot be normalized and SMS delivery may fail."
+msgstr ""
+
+#: src/Admin/Dashboard.php:374
+msgid "Default Country Code is not configured"
+msgstr ""
+
+#: src/Admin/Dashboard.php:381
+msgid "Configure now"
+msgstr ""
+
+#: src/Admin/Dashboard.php:417
+#, php-format
+msgid "%1$d phone number could not be normalized recently and may not have been delivered:<br>%2$s<br><em>Dismiss this notice to clear the log. Captured values are stored only in WordPress options on this site.</em>"
+msgid_plural "%1$d phone numbers could not be normalized recently and may not have been delivered:<br>%2$s<br><em>Dismiss this notice to clear the log. Captured values are stored only in WordPress options on this site.</em>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Admin/Dashboard.php:426
+msgid "Recent phone normalization failures"
+msgstr ""
+
+#: src/Admin/Dashboard.php:472
+#, php-format
+msgid "Improve delivery reliability for %d phone number"
+msgid_plural "Improve delivery reliability for %d phone numbers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Admin/Dashboard.php:480
+msgid "Some of your stored numbers are in local format, which can cause delivery failures on modern SMS gateways. We can add the country code for you — it takes under a minute, includes a preview step, and everything is backed up and reversible."
+msgstr ""
+
+#: src/Admin/Dashboard.php:490
+msgid "Review and fix"
+msgstr ""
+
+#. translators: %s: API URL
+#: src/Admin/LicenseManagement/ApiCommunicator.php:42
+#, php-format
+msgid "No products were found. The API returned an empty response from the following URL: %s"
+msgstr ""
+
+#. translators: %s: Error message.
+#: src/Admin/LicenseManagement/ApiCommunicator.php:50
+#, php-format
+msgid "Unable to retrieve product list from the remote server, %s. Please check the remote server connection or your remote work configuration."
+msgstr ""
+
+#: src/Admin/LicenseManagement/ApiCommunicator.php:152
+msgid "License key is not valid. Please enter a valid license and try again."
+msgstr ""
+
+#: src/Admin/LicenseManagement/ApiCommunicator.php:165
+msgid "Invalid license response!"
+msgstr ""
+
+#: src/Admin/LicenseManagement/ApiCommunicator.php:171
+msgid "Unknown error!"
+msgstr ""
+
+#. translators: %s: Add-On name
+#: src/Admin/LicenseManagement/ApiCommunicator.php:198
+#, php-format
+msgid "The license is not related to the requested Add-On <b>%s</b>."
+msgstr ""
+
+#. translators: 1: Add-on slug 2: error message
+#: src/Admin/LicenseManagement/LicenseMigration.php:123
+#, php-format
+msgid "Failed to migrate license for %1$s: %2$s"
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginActions.php:59
+#: src/Admin/LicenseManagement/Plugin/PluginActions.php:96
+#: src/Controller/AjaxControllerAbstract.php:55
+#: src/Controller/NumberMigrationAjax.php:26
+msgid "You do not have permission to perform this action."
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginActions.php:68
+#: src/Controller/LicenseManagerAjax.php:51
+msgid "License key is missing."
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginActions.php:74
+#: src/Controller/LicenseManagerAjax.php:57
+msgid "You're All Set! Your License is Successfully Activated!"
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginActions.php:103
+#: src/Controller/LicenseManagerAjax.php:71
+msgid "Plugin slug is missing."
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginDecorator.php:151
+#: resources/react/src/components/modals/AllInOneModal.jsx:145
+#: resources/react/src/pages/Integrations.jsx:28
+msgid "Not Installed"
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginDecorator.php:153
+msgid "Needs License"
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginDecorator.php:155
+msgid "License Expired"
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginDecorator.php:159
+#: src/Service/Assets/Handlers/AdminHandler.php:268
+msgid "Activated"
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginDecorator.php:161
+#: resources/react/src/pages/Integrations.jsx:29
+#: resources/react/src/pages/Privacy.jsx:394
+msgid "Unknown"
+msgstr ""
+
+#: src/Admin/LicenseManagement/Plugin/PluginHandler.php:83
+msgid "Plugin is not installed!"
+msgstr ""
+
+#: src/Admin/Notification/NotificationActions.php:39
+msgid "Missing notification_id parameter."
+msgstr ""
+
+#: src/Admin/Notification/NotificationActions.php:45
+msgid "All notifications have been dismissed."
+msgstr ""
+
+#: src/Admin/Notification/NotificationActions.php:49
+msgid "Invalid notification_id."
+msgstr ""
+
+#: src/Admin/Notification/NotificationActions.php:55
+msgid "Notification has been dismissed."
+msgstr ""
+
+#. translators: %s: is the API URL that returned an empty response.
+#: src/Admin/Notification/NotificationFetcher.php:57
+#, php-format
+msgid "No notifications were found. The API returned an empty response from the following URL: %s"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:25
+msgid "This section provides debug information about your WP SMS plugin settings."
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:38
+#: src/Admin/SiteHealthInfo.php:251
+#: src/Admin/SiteHealthInfo.php:261
+#: src/Admin/SiteHealthInfo.php:400
+#: src/Admin/SiteHealthInfo.php:488
+#: src/Admin/SiteHealthInfo.php:496
+#: src/Admin/SiteHealthInfo.php:550
+#: src/Admin/SiteHealthInfo.php:589
+#: src/Admin/SiteHealthInfo.php:626
+#: src/Admin/SiteHealthInfo.php:656
+#: src/Services/WooCommerce/WooCommerceCheckout.php:45
+#: resources/react/src/components/layout/AdminNotices.jsx:140
+#: resources/react/src/pages/Overview.jsx:138
+#: resources/react/src/pages/TwoWayCommands.jsx:301
+#: resources/react/src/pages/TwoWayCommands.jsx:661
+#: resources/react/src/pages/TwoWayCommands.jsx:714
+msgid "Enabled"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:38
+#: src/Admin/SiteHealthInfo.php:251
+#: src/Admin/SiteHealthInfo.php:403
+#: src/Admin/SiteHealthInfo.php:488
+#: src/Admin/SiteHealthInfo.php:496
+#: src/Admin/SiteHealthInfo.php:550
+#: src/Admin/SiteHealthInfo.php:589
+#: src/Admin/SiteHealthInfo.php:626
+#: src/Admin/SiteHealthInfo.php:656
+#: src/Services/WooCommerce/WooCommerceCheckout.php:47
+#: resources/react/src/pages/Overview.jsx:138
+#: resources/react/src/pages/TwoWayCommands.jsx:302
+#: resources/react/src/pages/TwoWayCommands.jsx:674
+#: resources/react/src/pages/TwoWayCommands.jsx:715
+msgid "Disabled"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:51
+msgid "Plugin Version"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:58
+msgid "Database Version"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:59
+#: src/Admin/SiteHealthInfo.php:86
+#: src/Admin/SiteHealthInfo.php:93
+#: src/Admin/SiteHealthInfo.php:100
+#: src/Admin/SiteHealthInfo.php:132
+#: src/Admin/SiteHealthInfo.php:319
+#: src/Admin/SiteHealthInfo.php:362
+#: src/Admin/SiteHealthInfo.php:406
+#: src/Admin/SiteHealthInfo.php:505
+#: src/Admin/SiteHealthInfo.php:553
+#: src/Admin/SiteHealthInfo.php:589
+#: src/Admin/SiteHealthInfo.php:626
+#: src/Admin/SiteHealthInfo.php:656
+#: src/Admin/SiteHealthInfo.php:706
+msgid "Not Set"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:99
+msgid "SMS Gateway Name"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:106
+msgid "SMS Gateway Status"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:112
+msgid "SMS Gateway Incoming Message"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:118
+msgid "SMS Gateway Send Bulk SMS"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:124
+msgid "SMS Gateway Send MMS"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:131
+msgid "SMS Gateway Delivery Method"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:138
+msgid "SMS Gateway Unicode Messaging"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:145
+msgid "SMS Gateway Number Formatting"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:154
+msgid "SMS Gateway Restrict to Local Numbers"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:161
+msgid "SMS Gateway Allowed Countries for SMS"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:168
+msgid "SMS Newsletter Group Visibility in Form"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:175
+msgid "SMS Newsletter Group Selection"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:182
+msgid "SMS Newsletter Subscription Confirmation"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:189
+msgid "Message Button Status"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:203
+msgid "Shorten URLs"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:210
+msgid "Google reCAPTCHA Integration"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:217
+msgid "Login With SMS"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:224
+msgid "Two-Factor Authentication with SMS"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:231
+msgid "Create User on SMS Login"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:238
+msgid "Contact Form 7 Metabox"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:260
+msgid "Formidable Integration"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:267
+msgid "Formidable Metabox"
+msgstr ""
+
+#. translators: %s: number of days
+#: src/Admin/SiteHealthInfo.php:332
+#, php-format
+msgid "%s day"
+msgid_plural "%s days"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: number of hours
+#: src/Admin/SiteHealthInfo.php:343
+#, php-format
+msgid "%s hour"
+msgid_plural "%s hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: number of minutes
+#: src/Admin/SiteHealthInfo.php:354
+#, php-format
+msgid "%s minute"
+msgid_plural "%s minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Admin/SiteHealthInfo.php:380
+msgid "WooPro: Cart Abandonment Recovery"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:381
+msgid "WooPro: Cart abandonment threshold"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:382
+msgid "WooPro: Cart abandonment Overwrite mobile number"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:383
+msgid "WooPro: Cart abandonment Create coupon"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:384
+msgid "WooPro: Cart abandonment Send sms after"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:385
+msgid "WooPro: Show Button in Login Page"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:386
+msgid "WooPro: Show Button in Forgot Password Page"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:387
+msgid "WooPro: Enable SMS Password Reset"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:388
+msgid "WooPro: Confirmation Checkbox"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:389
+msgid "WooPro: Enable Mobile Verification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:390
+msgid "WooPro: Automatic Registration via SMS"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:391
+msgid "WooPro: Skip Verification for Logged-In Users"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:392
+msgid "WooPro: Required Countries for Mobile Verification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:431
+msgid "Do not update"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:431
+msgid "Update phone number"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:522
+msgid "Booking Calendar: Admin New Booking Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:523
+msgid "Booking Calendar: Customer New Booking Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:524
+msgid "Booking Calendar: Booking Approved Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:525
+msgid "Booking Calendar: Booking Cancelled Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:526
+msgid "BookingPress: Admin Approved Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:527
+msgid "BookingPress: Customer Approved Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:528
+msgid "BookingPress: Admin Pending Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:529
+msgid "BookingPress: Customer Pending Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:530
+msgid "BookingPress: Admin Rejected Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:531
+msgid "BookingPress: Customer Rejected Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:532
+msgid "BookingPress: Admin Cancelled Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:533
+msgid "BookingPress: Customer Cancelled Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:534
+msgid "Woo Appointments: Admin New Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:535
+msgid "Woo Appointments: Admin Cancelled Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:536
+msgid "Woo Appointments: Customer Cancelled Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:537
+msgid "Woo Appointments: Admin Rescheduled Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:538
+msgid "Woo Appointments: Customer Confirmed Appointment"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:539
+msgid "Woo Bookings: Admin New Booking"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:540
+msgid "Woo Bookings: Admin Cancelled Booking"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:541
+msgid "Woo Bookings: Customer Cancelled Booking"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:542
+msgid "Woo Bookings: Customer Confirmed Booking"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:577
+msgid "FluentCRM: Contact Subscribed Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:578
+msgid "FluentCRM: Contact Unsubscribed Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:579
+msgid "FluentCRM: Contact Pending Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:580
+msgid "Fluent Support: Ticket Created"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:581
+msgid "Fluent Support: Customer Response"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:582
+msgid "Fluent Support: Agent Assigned"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:583
+msgid "Fluent Support: Ticket Closed"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:612
+msgid "Paid Memberships Pro: User Registered Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:613
+msgid "Paid Memberships Pro: Membership Confirmed Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:614
+msgid "Paid Memberships Pro: Membership Cancelled Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:615
+msgid "Paid Memberships Pro: Membership Expired Notification"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:616
+msgid "Simple Membership: Admin Notified on User Registration"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:617
+msgid "Simple Membership: Membership Level Updated"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:618
+msgid "Simple Membership: Membership Expired"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:619
+msgid "Simple Membership: Membership Cancelled"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:620
+msgid "Simple Membership: Payment Received (Admin)"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:649
+msgid "Two-Way: Forward Incoming SMS to Admin"
+msgstr ""
+
+#: src/Admin/SiteHealthInfo.php:650
+msgid "Two-Way: Forward Incoming SMS to Email"
+msgstr ""
+
+#: src/BackgroundProcess/SmsDispatcher.php:90
+msgid "SMS delivery is in progress as a background task; please review the Outbox for updates."
+msgstr ""
+
+#: src/Blocks/BlockAssetsManager.php:23
+msgid "WP SMS: The \"register_block_type\" function is not supported in this version of WordPress."
+msgstr ""
+
+#. translators: %s: Class name
+#: src/Blocks/BlockAssetsManager.php:34
+#, php-format
+msgid "WP SMS: Widget encountered an error, class %s could not be loaded."
+msgstr ""
+
+#: src/Blocks/SendSmsBlock.php:43
+msgid "All Roles"
+msgstr ""
+
+#: src/Blocks/SendSmsBlock.php:54
+#: resources/react/src/pages/Newsletter.jsx:85
+msgid "Select a group"
+msgstr ""
+
+#: src/Blocks/WooSmsOptInBlock.php:23
+msgid "Status Update SMS Notifications"
+msgstr ""
+
+#: src/Blocks/WooSmsOptInBlock.php:24
+#: src/Services/WooCommerce/WooCommerceCheckout.php:62
+msgid "I would like to get notification about any change in my order via SMS."
+msgstr ""
+
+#: src/Components/Event.php:129
+msgid "Daily"
+msgstr ""
+
+#: src/Components/Event.php:136
+msgid "Weekly"
+msgstr ""
+
+#: src/Components/Event.php:143
+msgid "Bi-Weekly"
+msgstr ""
+
+#: src/Components/Event.php:150
+msgid "Monthly"
+msgstr ""
+
+#. translators: %s is an example phone number formatted in the admin's locale.
+#: src/Components/NumberParser.php:45
+#, php-format
+msgid "For example: %s"
+msgstr ""
+
+#. translators: 1: the value the user submitted, 2: example formatted number
+#: src/Components/NumberParser.php:53
+#, php-format
+msgid "Could not understand \"%1$s\" as a phone number. Please enter a complete phone number. %2$s"
+msgstr ""
+
+#. translators: %s: example formatted number
+#: src/Components/NumberParser.php:66
+#, php-format
+msgid "The mobile number is missing a country code. Please include it (the leading +). %s"
+msgstr ""
+
+#. translators: 1: the value the user submitted, 2: example formatted number
+#: src/Components/NumberParser.php:78
+#, php-format
+msgid "\"%1$s\" does not look like a complete phone number. %2$s"
+msgstr ""
+
+#. translators: 1: the value the user submitted, 2: example formatted number
+#: src/Components/NumberParser.php:92
+#, php-format
+msgid "The country code on \"%1$s\" is not allowed. %2$s"
+msgstr ""
+
+#: src/Components/NumberParser.php:249
+msgid "Default Country Code is not configured. Please set it in WP SMS Phone settings."
+msgstr ""
+
+#: src/Components/NumberParser.php:293
+msgid "This user mobile field is invalid."
+msgstr ""
+
+#. translators: %s: Response message
+#. translators: %s: Error message
+#: src/Components/RemoteRequest.php:142
+#: src/Webhook/WebhookAbstract.php:78
+#, php-format
+msgid "Failed to get success response, %s"
+msgstr ""
+
+#: src/Components/RemoteRequest.php:248
+msgid "Unknown error"
+msgstr ""
+
+#: src/Components/Sms.php:54
+msgid "Mobile number not found, please make sure the mobile field in settings page is configured."
+msgstr ""
+
+#: src/Components/Sms.php:59
+msgid "Message content cannot be empty. Please provide a valid SMS message."
+msgstr ""
+
+#. translators: %s: View file path
+#: src/Components/View.php:31
+#, php-format
+msgid "View file not found: %s"
+msgstr ""
+
+#. translators: %s: Field name
+#. translators: %s: field name
+#: src/Controller/AjaxControllerAbstract.php:63
+#: src/Controller/RecipientCountsAjax.php:47
+#, php-format
+msgid "Field %s is required."
+msgstr ""
+
+#. translators: %s: Class name
+#: src/Controller/AjaxControllerAbstract.php:111
+#, php-format
+msgid "Public property %s not provided"
+msgstr ""
+
+#: src/Controller/ExportAjax.php:100
+msgid "There is no data to export"
+msgstr ""
+
+#: src/Controller/ImportSubscriberCsv.php:44
+msgid "There is no file to import. Please try again to upload the file."
+msgstr ""
+
+#: src/Controller/ImportSubscriberCsv.php:90
+msgid "The group ID is not valid"
+msgstr ""
+
+#: src/Controller/LicenseManagerAjax.php:40
+#: src/Controller/OnBoardingTestGateway.php:36
+msgid "Invalid action."
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:51
+msgid "Invalid sub-action."
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:88
+msgid "User Mobile Numbers"
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:98
+msgid "OTP Records"
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:107
+msgid "OTP Attempts"
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:116
+msgid "Campaign Targets"
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:125
+msgid "Scheduled Messages"
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:134
+msgid "Repeating Messages"
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:143
+#: resources/react/src/lib/pageRegistry.js:73
+msgid "Outbox"
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:396
+#: src/Controller/NumberMigrationAjax.php:776
+msgid "Another migration is already running. Please wait for it to finish before retrying."
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:837
+msgid "No backup found. Cannot revert."
+msgstr ""
+
+#: src/Controller/NumberMigrationAjax.php:996
+msgid "Please select a country code to continue."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:65
+msgid "Deactivated!"
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:67
+msgid "Your SMS gateway is successfully connected and ready to send messages."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:68
+msgid "There’s an issue connecting to your SMS gateway. Please double-check your credentials and settings."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:73
+msgid "Your current credit or balance in the gateway account."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:77
+#: src/Controller/OnBoardingTestGateway.php:84
+#: src/Controller/OnBoardingTestGateway.php:91
+msgid "Supported"
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:77
+#: src/Controller/OnBoardingTestGateway.php:84
+#: src/Controller/OnBoardingTestGateway.php:91
+msgid "Not Supported!"
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:79
+msgid "Your gateway can receive inbound messages on the configured number."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:80
+msgid "The gateway you’ve selected does not support receiving inbound messages. If you need this feature, pick a different gateway."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:86
+msgid "You can send messages to large groups of recipients (mass or marketing campaigns)."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:87
+msgid "Bulk messaging isn’t available with this gateway. Choose a provider that offers mass-sending capabilities if needed."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:93
+msgid "WhatsApp Messaging is enabled for your gateway."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:94
+msgid "This gateway does not support WhatsApp messaging. If you require this feature, please switch to a compatible gateway."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:108
+msgid "This is a test from WP SMS onboarding process."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:117
+msgid "Did you receive the test SMS?"
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:118
+msgid "Please check your device to confirm whether you received the message."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:127
+msgid "Failed to send test SMS."
+msgstr ""
+
+#: src/Controller/OnBoardingTestGateway.php:132
+msgid "Error sending test SMS: "
+msgstr ""
+
+#: src/Controller/PrivacyDataAjax.php:37
+msgid "Sorry, you do not have permission to perform this action!"
+msgstr ""
+
+#: src/Controller/PrivacyDataAjax.php:42
+msgid "Please enter the mobile number!"
+msgstr ""
+
+#: src/Controller/PrivacyDataAjax.php:61
+msgid "User with % s mobile number is removed completely!"
+msgstr ""
+
+#: src/Controller/PrivacyDataAjax.php:125
+msgid "User with this mobile number was not found!"
+msgstr ""
+
+#: src/Controller/PrivacyDataAjax.php:166
+msgid "The CSV file generated successfully!"
+msgstr ""
+
+#: src/Controller/PublicSubscribeAjax.php:29
+#: src/Controller/PublicUnsubscribeAjax.php:34
+#: src/Service/Assets/Handlers/FrontendHandler.php:69
+msgid "Please accept the privacy checkbox to continue."
+msgstr ""
+
+#: src/Controller/PublicUnsubscribeAjax.php:43
+msgid "Too many requests. Please try again later."
+msgstr ""
+
+#: src/Controller/PublicUnsubscribeAjax.php:58
+msgid "The provided mobile number is not subscribed."
+msgstr ""
+
+#: src/Controller/PublicUnsubscribeAjax.php:72
+msgid "This mobile number is not subscribed to the selected group(s)."
+msgstr ""
+
+#: src/Controller/PublicUnsubscribeAjax.php:106
+msgid "You have successfully unsubscribed from the newsletter."
+msgstr ""
+
+#: src/Controller/RecipientCountsAjax.php:73
+msgid "Invalid type."
+msgstr ""
+
+#: src/Controller/UploadSubscriberCsv.php:33
+msgid "Choose a *.csv file, first."
+msgstr ""
+
+#: src/Controller/UploadSubscriberCsv.php:38
+msgid "Only *.csv files are allowed."
+msgstr ""
+
+#: src/Controller/UploadSubscriberCsv.php:45
+msgid "The uploaded file doesn't contain any data."
+msgstr ""
+
+#: src/Controller/UploadSubscriberCsv.php:87
+msgid "File uploaded successfully."
+msgstr ""
+
+#: src/Decorators/NotificationDecorator.php:145
+msgid "ago"
+msgstr ""
+
+#: src/Exceptions/SmsGatewayException.php:14
+msgid "PHP SOAP extension is not enabled; please ask your hosting provider to enable SOAP in your PHP configuration."
+msgstr ""
+
+#: src/Exceptions/SmsGatewayException.php:22
+msgid "Invalid SMS gateway credentials provided."
+msgstr ""
+
+#. translators: %s: SMS gateway endpoint
+#: src/Exceptions/SmsGatewayException.php:32
+#, php-format
+msgid "Failed to connect to SMS gateway endpoint: %s."
+msgstr ""
+
+#. translators: %s: SMS gateway error
+#: src/Exceptions/SmsGatewayException.php:44
+#, php-format
+msgid "SMS gateway returned an error: %s."
+msgstr ""
+
+#: src/Exceptions/SmsGatewayException.php:54
+msgid "SMS gateway returned an unexpected or invalid response."
+msgstr ""
+
+#. translators: %s: SMS gateway feature name
+#: src/Exceptions/SmsGatewayException.php:64
+#, php-format
+msgid "SMS gateway does not support the feature: %s."
+msgstr ""
+
+#: src/Exceptions/SmsGatewayException.php:74
+msgid "Failed to send SMS message due to a gateway error."
+msgstr ""
+
+#. translators: %s: error message
+#: src/Exceptions/SystemErrorException.php:14
+#, php-format
+msgid "System error: %s"
+msgstr ""
+
+#: src/Helper.php:460
+#: src/Helper.php:464
+msgid "This mobile is already registered, please choose another one."
+msgstr ""
+
+#: src/Notice/NoticeManager.php:86
+#: src/Notice/NoticeManager.php:99
+msgid "Phone settings"
+msgstr ""
+
+#. translators: %s: link to Phone settings page
+#: src/Notice/NoticeManager.php:90
+#, php-format
+msgid "You need to configure the Mobile field option in %s to send SMS to customers."
+msgstr ""
+
+#. translators: %s: link to Phone settings page
+#: src/Notice/NoticeManager.php:103
+#, php-format
+msgid "You need to configure the Mobile field option in %s to use login with SMS functionality."
+msgstr ""
+
+#. translators: %s: Phone numbers
+#: src/Notification/Handler/WooCommerceOrderNotification.php:68
+#, php-format
+msgid "Successfully send SMS notification to %s"
+msgstr ""
+
+#. translators: %1$s: Phone number, %2$s: Error message
+#: src/Notification/Handler/WooCommerceOrderNotification.php:80
+#, php-format
+msgid "Failed to send SMS notification to %1$s. Error: %2$s"
+msgstr ""
+
+#: src/Notification/Notification.php:71
+msgid "This number has opted out of receiving SMS notifications."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:175
+msgid "Send SMS?"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:176
+msgid "The SMS will be sent if the <b>Note to the customer</b> is selected."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:179
+msgid "Edit Subscriber"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:180
+msgid "Edit Group"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:187
+#: resources/react/src/pages/SmsCampaigns.jsx:998
+#: resources/react/src/pages/TwoWayInbox.jsx:767
+#: resources/react/src/pages/TwoWayInbox.jsx:870
+msgid "characters"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:211
+#: resources/react/src/lib/tableColumns.jsx:215
+#: resources/react/src/lib/tableColumns.jsx:442
+#: resources/react/src/lib/tableColumns.jsx:577
+#: resources/react/src/pages/SmsCampaigns.jsx:549
+msgid "View Details"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:212
+msgid "Reload"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:213
+msgid "Online Visitors"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:214
+msgid "Realtime"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:215
+#: src/Service/Assets/Handlers/AdminHandler.php:241
+msgid "Visitors"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:216
+#: src/Service/Assets/Handlers/AdminHandler.php:251
+msgid "Views"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:217
+#: resources/react/src/pages/CartAbandonment.jsx:454
+#: resources/react/src/pages/TwoWayInbox.jsx:500
+msgid "Today"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:218
+#: resources/react/src/pages/CartAbandonment.jsx:455
+msgid "Yesterday"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:219
+#: src/Service/Assets/Handlers/AdminHandler.php:225
+msgid "Last 7 days"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:220
+msgid "This week"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:221
+msgid "Last week"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:222
+#: src/Service/Assets/Handlers/AdminHandler.php:226
+msgid "Last 30 days"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:223
+msgid "This month"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:224
+msgid "Last month"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:227
+msgid "Last 60 days"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:228
+msgid "Last 90 days"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:229
+msgid "Last 6 months"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:230
+msgid "Last 12 months"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:231
+msgid "This year (Jan-Today)"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:232
+msgid "Last year"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:234
+msgid "Daily Total"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:236
+msgid "Time"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:237
+msgid "Browsers"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:238
+msgid "#"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:239
+msgid "Country Flag"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:240
+#: resources/react/src/components/NumberMigrationModal.jsx:43
+#: resources/react/src/lib/tableColumns.jsx:307
+msgid "Country"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:243
+msgid "Page"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:244
+msgid "Page Link"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:245
+msgid "Domain Address"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:246
+msgid "Search Term"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:247
+msgid "Visitor's Browser"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:248
+msgid "Visitor's City"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:249
+msgid "IP Address/Hash"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:250
+msgid "Referring Site"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:252
+msgid "User Agent"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:253
+msgid "Operating System"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:254
+msgid "Browser/OS Version"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:255
+msgid "Visited Page"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:256
+msgid "Your WP SMS settings are privacy-compliant."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:257
+msgid "Your WP SMS settings are not privacy-compliant. Please update your settings."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:258
+msgid "No recent data available."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:259
+msgid "Published"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:260
+msgid "Author"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:261
+msgid "View Detailed Analytics"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:262
+msgid "Enable Now"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:263
+msgid "Receive Weekly Email Reports"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:265
+msgid "Previous period"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:266
+msgid "View Content"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:267
+msgid "Downloading"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:270
+msgid "Activating"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:271
+msgid "Already installed"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:272
+msgid "Installed"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:274
+#: resources/react/src/pages/AddOns.jsx:325
+msgid "Retry"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:275
+msgid "Redirecting... Please wait"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:276
+msgid "Update License"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:277
+msgid "Please select the group(s) ..."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:278
+#: resources/react/src/components/ui/searchable-select.jsx:185
+msgid "No results found"
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:279
+msgid "Please fix the highlighted field(s) below."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:280
+msgid "Search ..."
+msgstr ""
+
+#: src/Service/Assets/Handlers/AdminHandler.php:281
+msgid "Users have the mobile number."
+msgstr ""
+
+#: src/Service/Assets/Handlers/FrontendHandler.php:65
+msgid "Unknown Error! Check your connection and try again."
+msgstr ""
+
+#: src/Service/Assets/Handlers/FrontendHandler.php:66
+#: resources/react/src/components/migration/CountryStep.jsx:90
+#: resources/react/src/components/migration/ReviewStep.jsx:244
+msgid "Loading..."
+msgstr ""
+
+#: src/Services/Formidable/FormidableManager.php:19
+msgid "Formidable"
+msgstr ""
+
+#: src/Services/Formidable/FormidableManager.php:52
+msgid "This option adds SMS Notification tab in the Settings forms."
+msgstr ""
+
+#: src/Services/Formidable/FormidableManager.php:57
+#: src/Services/Forminator/ForminatorManager.php:102
+msgid "Not active"
+msgstr ""
+
+#: src/Services/Formidable/FormidableManager.php:59
+msgid "Formidable plugin should be enable to run this tab"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:15
+#: resources/react/src/pages/Integrations.jsx:873
+#: resources/react/src/pages/Integrations.jsx:1028
+msgid "Forminator"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:35
+msgid "No data"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:37
+msgid "There is no form available on Forminator plugin, please first add your forms."
+msgstr ""
+
+#. translators: %s: Form name
+#: src/Services/Forminator/ForminatorManager.php:46
+#, php-format
+msgid "Form notifications (%s)"
+msgstr ""
+
+#. translators: %s: Form name
+#: src/Services/Forminator/ForminatorManager.php:49
+#, php-format
+msgid "By enabling this option you can send SMS notification once the %s form is submitted"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:54
+#: resources/react/src/pages/Integrations.jsx:129
+#: resources/react/src/pages/Integrations.jsx:132
+#: resources/react/src/pages/Integrations.jsx:307
+#: resources/react/src/pages/Integrations.jsx:310
+#: resources/react/src/pages/Integrations.jsx:486
+#: resources/react/src/pages/Integrations.jsx:489
+#: resources/react/src/pages/Integrations.jsx:662
+#: resources/react/src/pages/Integrations.jsx:665
+msgid "Send SMS to a number"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:60
+#: resources/react/src/pages/Integrations.jsx:141
+#: resources/react/src/pages/Integrations.jsx:319
+#: resources/react/src/pages/Integrations.jsx:498
+#: resources/react/src/pages/Integrations.jsx:674
+msgid "Phone number(s)"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:62
+#: resources/react/src/pages/Integrations.jsx:150
+#: resources/react/src/pages/Integrations.jsx:328
+#: resources/react/src/pages/Integrations.jsx:507
+#: resources/react/src/pages/Integrations.jsx:683
+msgid "Enter the mobile number(s) to receive SMS, to separate numbers, use the latin comma."
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:68
+#: src/Services/Forminator/ForminatorManager.php:92
+#: resources/react/src/pages/Integrations.jsx:161
+#: resources/react/src/pages/Integrations.jsx:222
+#: resources/react/src/pages/Integrations.jsx:339
+#: resources/react/src/pages/Integrations.jsx:400
+#: resources/react/src/pages/Integrations.jsx:518
+#: resources/react/src/pages/Integrations.jsx:579
+#: resources/react/src/pages/Integrations.jsx:694
+#: resources/react/src/pages/Integrations.jsx:755
+msgid "Enter your message content."
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:77
+#: resources/react/src/pages/Integrations.jsx:185
+#: resources/react/src/pages/Integrations.jsx:188
+#: resources/react/src/pages/Integrations.jsx:363
+#: resources/react/src/pages/Integrations.jsx:366
+#: resources/react/src/pages/Integrations.jsx:542
+#: resources/react/src/pages/Integrations.jsx:545
+#: resources/react/src/pages/Integrations.jsx:718
+#: resources/react/src/pages/Integrations.jsx:721
+msgid "Send SMS to field"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:83
+#: resources/react/src/pages/Integrations.jsx:197
+#: resources/react/src/pages/Integrations.jsx:375
+#: resources/react/src/pages/Integrations.jsx:554
+#: resources/react/src/pages/Integrations.jsx:730
+msgid "A field of the form"
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:86
+#: resources/react/src/pages/Integrations.jsx:211
+#: resources/react/src/pages/Integrations.jsx:389
+#: resources/react/src/pages/Integrations.jsx:568
+#: resources/react/src/pages/Integrations.jsx:744
+msgid "Select the field of your form."
+msgstr ""
+
+#: src/Services/Forminator/ForminatorManager.php:104
+msgid "Forminator plugin should be enable to run this tab"
+msgstr ""
+
+#: src/Services/Gateway/GatewayRegistry.php:188
+msgid "Custom Gateway"
+msgstr ""
+
+#: src/Services/Gateway/GatewayRegistry.php:193
+msgid "Test Gateway"
+msgstr ""
+
+#: src/Services/Hooks/HooksManager.php:30
+#: resources/blocks/send-sms/edit.js:57
+#: resources/react/src/lib/pageRegistry.js:190
+#: resources/react/src/lib/pageRegistry.js:213
+#: resources/react/src/lib/pageRegistry.js:231
+msgid "Settings"
+msgstr ""
+
+#: src/Services/Hooks/HooksManager.php:34
+msgid "Get All-in-One"
+msgstr ""
+
+#: src/Services/MessageButton/ChatBoxDecorator.php:25
+#: resources/react/src/pages/MessageButton.jsx:216
+msgid "Chat with Us!"
+msgstr ""
+
+#: src/Services/MessageButton/ChatBoxDecorator.php:30
+msgid "Talk to Us"
+msgstr ""
+
+#: src/Services/MessageButton/ChatBoxDecorator.php:40
+#: resources/react/src/pages/MessageButton.jsx:289
+msgid "Chat with us on WhatsApp for instant support!"
+msgstr ""
+
+#: src/Services/MessageButton/ChatBoxDecorator.php:50
+msgid "Related Articles"
+msgstr ""
+
+#: src/Services/MessageButton/ChatBoxDecorator.php:85
+#: resources/react/src/pages/MessageButton.jsx:359
+#: resources/react/src/pages/MessageButton.jsx:367
+#: resources/react/src/pages/MessageButton.jsx:702
+#: resources/react/src/pages/Overview.jsx:328
+msgid "Quick Links"
+msgstr ""
+
+#. translators: %s: Site name
+#: src/Services/Report/EmailReportGenerator.php:53
+#, php-format
+msgid "%s - SMS Report"
+msgstr ""
+
+#: src/Services/Report/EmailReportGenerator.php:60
+msgid "SMS Report"
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:29
+#: src/Services/Subscriber/SubscriberUtil.php:107
+msgid "Name and Mobile Number are required!"
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:61
+msgid "Service provider is not available for send activate key to your mobile. Please contact with site."
+msgstr ""
+
+#. translators: %s: Activation code
+#: src/Services/Subscriber/SubscriberUtil.php:76
+#, php-format
+msgid "Your activation code: %s"
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:79
+msgid "To activate your subscription, the activation has been sent to your number."
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:136
+msgid "The required parameters must be valued!"
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:163
+msgid "Too many attempts. Please try again later."
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:170
+msgid "Activation code is wrong!"
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:187
+msgid "Your subscription done successfully!"
+msgstr ""
+
+#: src/Services/Subscriber/SubscriberUtil.php:191
+msgid "Not found the number!"
+msgstr ""
+
+#: src/Services/WooCommerce/WooCommerceCheckout.php:42
+msgid "Status Update SMS Notifications:"
+msgstr ""
+
+#: src/SmsOtp/Generator.php:127
+msgid "Provided $length argument must be between 4 and 10."
+msgstr ""
+
+#: src/SmsOtp/Generator.php:170
+msgid "OTPs generated for this number has reached its limit, please try some other time."
+msgstr ""
+
+#: src/SmsOtp/Verifier.php:184
+msgid "Too many verification attempts, please try some other time."
+msgstr ""
+
+#: src/Traits/AjaxUtilityTrait.php:21
+msgid "Request is not a valid AJAX request. Please try again!"
+msgstr ""
+
+#: src/Traits/AjaxUtilityTrait.php:41
+msgid "The request does not contain a valid nonce. Please try again."
+msgstr ""
+
+#: src/Traits/AjaxUtilityTrait.php:57
+msgid "You do not have permission to perform this action. Please contact an administrator."
+msgstr ""
+
+#: src/Traits/AjaxUtilityTrait.php:76
+msgid "The request does not come from the admin dashboard or is invalid."
+msgstr ""
+
+#: src/User/MobileFieldHandler/AbstractFieldHandler.php:65
+#: src/User/MobileFieldHandler/WooCommerceAddMobileFieldHandler.php:93
+#: src/User/MobileFieldHandler/WordPressMobileFieldHandler.php:87
+msgid "<strong>ERROR</strong>: You must enter the mobile number."
+msgstr ""
+
+#: src/User/MobileFieldHandler/WooCommerceAddMobileFieldHandler.php:126
+msgid "Mobile Number for getting SMS notification"
+msgstr ""
+
+#: src/User/RegisterUserViaPhone.php:39
+msgid "Another user with this phone number already exists."
+msgstr ""
+
+#: src/Utils/AdminHelper.php:28
+msgid "Invalid date request."
+msgstr ""
+
+#. translators: 1: number of hours 2: number of minutes
+#: src/Utils/TimeZone.php:240
+#, php-format
+msgid "%1$d hour %2$d minute ago"
+msgid_plural "%1$d hours %2$d minutes ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: number of hours
+#: src/Utils/TimeZone.php:255
+#, php-format
+msgid "%d hour ago"
+msgid_plural "%d hours ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: number of minutes
+#: src/Utils/TimeZone.php:268
+#, php-format
+msgid "%d minute ago"
+msgid_plural "%d minutes ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Utils/Validator.php:25
+msgid "The :attribute field is required."
+msgstr ""
+
+#: src/Utils/Validator.php:26
+msgid "The :attribute must be a valid email address."
+msgstr ""
+
+#: src/Utils/Validator.php:27
+msgid "The :attribute must be at least :min characters."
+msgstr ""
+
+#: src/Utils/Validator.php:28
+msgid "The :attribute may not be greater than :max characters."
+msgstr ""
+
+#: src/Utils/Validator.php:29
+msgid "The :attribute must be a number."
+msgstr ""
+
+#: src/Widget/Widgets/StatsWidget.php:146
+#: resources/react/src/pages/TwoWayInbox.jsx:369
+#: resources/react/src/pages/TwoWayInbox.jsx:577
+#: resources/react/src/pages/TwoWayInbox.jsx:695
+msgid "Plain"
+msgstr ""
+
+#: src/Widget/Widgets/StatsWidget.php:148
+#: resources/react/src/pages/Outbox.jsx:441
+msgid "Success Rate"
+msgstr ""
+
+#: views/components/lock-sections/notice-inactive-license-addon.php:4
+msgid "Notice:"
+msgstr ""
+
+#. translators: %s: URL to license activation page
+#: views/components/lock-sections/notice-inactive-license-addon.php:9
+#, php-format
+msgid ""
+"This add-on does not have an active license, which means it cannot receive updates, including important security updates.\r\n"
+"For uninterrupted access to updates and to keep your site secure, we strongly recommend activating a license. Activate your license <a href=\"%s\">here</a>."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:5
+msgid "Unlock Powerful Messaging Features with WP SMS Pro"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:9
+msgid "The options on this screen need the WP SMS Pro add-on. It extends WP SMS so you can:"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:14
+msgid "Access 350+ global gateways"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:14
+msgid "Pick the perfect provider for any region or budget."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:17
+msgid "Schedule or repeat messages"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:17
+msgid "Automate future drips, reminders, and promos."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:20
+msgid "Deep WooCommerce & BuddyPress messaging"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:20
+msgid "Text shoppers or community members right from WordPress."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:23
+msgid "SMS login & two-factor security"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:23
+msgid "Lock down accounts with one-time verification codes."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:26
+msgid "Plug-and-play with top plugins"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:26
+msgid "Gravity Forms, EDD, Awesome Support, Ultimate Member, and more."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:29
+msgid "Advanced WooCommerce alerts"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:29
+msgid "Order updates, low-stock warnings, product launches—all by SMS."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:35
+msgid "Get WP SMS Pro on its own, or save money with the All-in-One bundle that unlocks every premium add-on we make."
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:40
+msgid "Unlock Everything – All-in-One Plan"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:44
+msgid "Get WP SMS Pro only"
+msgstr ""
+
+#: views/components/lock-sections/unlock-all-in-one-addon.php:49
+msgid "14-day money-back guarantee. Instant download & updates."
+msgstr ""
+
+#: views/components/notices/action-notice.php:24
+#: resources/react/src/components/layout/AdminNotices.jsx:154
+#: resources/react/src/components/NumberMigrationModal.jsx:450
+msgid "Dismiss"
+msgstr ""
+
+#: resources/blocks/send-sms/edit.js:60
+msgid "Only for logged in users"
+msgstr ""
+
+#: resources/blocks/send-sms/edit.js:67
+msgid "Select Role"
+msgstr ""
+
+#: resources/blocks/send-sms/edit.js:76
+msgid "Max Characters"
+msgstr ""
+
+#: resources/react/src/api/wizardApi.js:81
+msgid "This is a test message from WSMS setup wizard."
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:106
+#: resources/react/src/pages/Overview.jsx:369
+msgid "Pro"
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:119
+msgid "No gateways found matching"
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:119
+msgid "No gateways found."
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:128
+msgid "These gateways are available with the Pro add-on:"
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:142
+#: resources/react/src/components/GatewayCard.jsx:170
+msgid "View all gateways"
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:160
+msgid "Can't find your gateway?"
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:160
+#: resources/react/src/components/GatewayCard.jsx:161
+msgid "We support"
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:160
+msgid "additional gateways."
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:161
+msgid "Looking for more gateways?"
+msgstr ""
+
+#: resources/react/src/components/GatewayCard.jsx:161
+msgid "additional gateways with the Pro add-on."
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:182
+#: resources/react/src/pages/Gateway.jsx:327
+msgid "Loading gateways..."
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:190
+msgid "Failed to load gateways. Please refresh the page."
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:202
+#: resources/react/src/pages/Gateway.jsx:299
+msgid "Search gateways..."
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:213
+#: resources/react/src/components/GatewaySelector.jsx:216
+#: resources/react/src/pages/Gateway.jsx:311
+#: resources/react/src/pages/Gateway.jsx:314
+msgid "All Regions"
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:214
+#: resources/react/src/pages/Gateway.jsx:312
+msgid "Search regions..."
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:245
+#: resources/react/src/pages/Gateway.jsx:347
+msgid "Other"
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:260
+#: resources/react/src/components/GatewaySelector.jsx:302
+#: resources/react/src/pages/Gateway.jsx:363
+#: resources/react/src/pages/Gateway.jsx:419
+msgid "Recommended"
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:272
+#: resources/react/src/pages/Gateway.jsx:389
+msgid "Global"
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:315
+#: resources/react/src/pages/Gateway.jsx:432
+msgid "All Gateways"
+msgstr ""
+
+#: resources/react/src/components/GatewaySelector.jsx:349
+msgid "Selected:"
+msgstr ""
+
+#: resources/react/src/components/layout/AdminNotices.jsx:138
+msgid "Failed, try again"
+msgstr ""
+
+#: resources/react/src/components/layout/BrandingFooter.jsx:78
+msgid "Made with"
+msgstr ""
+
+#: resources/react/src/components/layout/BrandingFooter.jsx:80
+msgid "for the WordPress community"
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:19
+msgid "Settings saved"
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:24
+msgid "Error saving settings"
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:25
+msgid "Please try again."
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:145
+msgid "Changes discarded"
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:166
+msgid "You have unsaved changes"
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:178
+msgid "Discard"
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:190
+#: resources/react/src/components/wizard/SetupWizard.jsx:417
+#: resources/react/src/pages/Groups.jsx:485
+#: resources/react/src/pages/Scheduled.jsx:680
+#: resources/react/src/pages/Scheduled.jsx:1280
+#: resources/react/src/pages/SmsCampaigns.jsx:473
+#: resources/react/src/pages/TwoWayCommands.jsx:576
+msgid "Saving..."
+msgstr ""
+
+#: resources/react/src/components/layout/FloatingSaveBar.jsx:195
+#: resources/react/src/pages/Scheduled.jsx:683
+#: resources/react/src/pages/Scheduled.jsx:1283
+#: resources/react/src/pages/TwoWayCommands.jsx:578
+msgid "Save Changes"
+msgstr ""
+
+#: resources/react/src/components/layout/Header.jsx:40
+#: resources/react/src/components/wizard/SetupWizard.jsx:103
+#: resources/react/src/components/wizard/WizardStepper.jsx:14
+msgid "All-in-One"
+msgstr ""
+
+#: resources/react/src/components/layout/Header.jsx:50
+msgid "License:"
+msgstr ""
+
+#: resources/react/src/components/layout/Header.jsx:64
+#: resources/react/src/components/layout/Header.jsx:87
+msgid "Upgrade"
+msgstr ""
+
+#: resources/react/src/components/layout/Header.jsx:86
+#: resources/react/src/components/modals/AllInOneModal.jsx:241
+#: resources/react/src/components/modals/AllInOneModal.jsx:276
+msgid "Upgrade to All-in-One"
+msgstr ""
+
+#: resources/react/src/components/layout/ListPageLayout.jsx:178
+#: resources/react/src/components/layout/ListPageLayout.jsx:231
+#: resources/react/src/components/ui/data-table.jsx:85
+msgid "No items found"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:24
+msgid "Support"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:97
+msgid "Checking gateway..."
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:99
+msgid "Gateway Connected"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:100
+msgid "Gateway not connected"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:152
+#: resources/react/src/lib/pageRegistry.js:125
+#: resources/react/src/pages/SendSms.jsx:268
+msgid "Gateway"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:174
+msgid "Refresh credit"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:195
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:93
+msgid "Configure"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:214
+msgid "What's New"
+msgstr ""
+
+#: resources/react/src/components/layout/Sidebar.jsx:230
+msgid "Enjoying WSMS?"
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:25
+msgid "Numbers like 202 555 0147 will become +1 202 555 0147"
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:28
+#, js-format
+msgid "Numbers like 202 555 0147 will become %s 202 555 0147"
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:33
+msgid "We need a country code just for this update — to convert your existing local-format numbers. Your International Number Input setting won't change."
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:36
+msgid "We'll use this country code to convert any number that doesn't already start with a +. You can change your plugin default later from Settings → General."
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:49
+msgid "Confirm your default country"
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:61
+#: resources/react/src/pages/PhoneConfig.jsx:239
+msgid "Default country code"
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:70
+msgid "Select country code..."
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:84
+#: resources/react/src/components/migration/PreviewStep.jsx:178
+#: resources/react/src/components/migration/ReviewStep.jsx:237
+#: resources/react/src/components/wizard/SetupWizard.jsx:410
+msgid "Back"
+msgstr ""
+
+#: resources/react/src/components/migration/CountryStep.jsx:93
+#: resources/react/src/components/wizard/SetupWizard.jsx:328
+msgid "Continue"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:23
+msgid "just now"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:27
+#, js-format
+msgid "We updated %1$d numbers across %2$d sources. A full backup was saved on %3$s and you can undo this at any time."
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:57
+msgid "Done. Your numbers now use the standard format."
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:85
+#, js-format
+msgid "%d records couldn't be updated."
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:97
+msgid "View details"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:104
+msgid "Copy error log"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:122
+msgid "What's next?"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:127
+msgid "Send a test SMS"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:131
+msgid "View your subscribers"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:144
+msgid "Undo this update"
+msgstr ""
+
+#: resources/react/src/components/migration/DoneStep.jsx:152
+msgid "Did we miss something? Re-scan to check"
+msgstr ""
+
+#: resources/react/src/components/migration/ExecuteStep.jsx:37
+msgid "Applying your changes…"
+msgstr ""
+
+#: resources/react/src/components/migration/ExecuteStep.jsx:40
+msgid "Processing in batches. This usually takes a few seconds. You can safely leave this tab open — we'll keep going."
+msgstr ""
+
+#: resources/react/src/components/migration/ExecuteStep.jsx:49
+msgid "Please don't close this tab until it's done."
+msgstr ""
+
+#: resources/react/src/components/migration/ExecuteStep.jsx:55
+msgid "This is a larger update than usual. Please don't close the tab — we'll keep working."
+msgstr ""
+
+#: resources/react/src/components/migration/ExecuteStep.jsx:64
+msgid "Something seems to be stuck. The update may still be running on the server."
+msgstr ""
+
+#: resources/react/src/components/migration/ExecuteStep.jsx:73
+msgid "Force refresh status"
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:17
+msgid "Let's get your numbers ready for reliable delivery."
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:20
+msgid "Some of your stored numbers are in local format (like 202 555 0147) instead of the international format your SMS gateway needs (+1 202 555 0147). We'll find them, show you exactly what will change, and apply the fix in one batch."
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:31
+msgid "We back everything up"
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:39
+msgid "You review before we change anything"
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:47
+msgid "One-click undo, anytime"
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:55
+msgid "Not now"
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:61
+msgid "Checking..."
+msgstr ""
+
+#: resources/react/src/components/migration/IntroStep.jsx:66
+msgid "Start check"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:38
+#, js-format
+msgid "We'll add +%s to numbers that are missing it, and normalize a few trunk-prefix variations. Numbers that are already in international format aren't touched."
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:57
+msgid "Review the changes"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:66
+#: resources/react/src/components/migration/ReviewStep.jsx:227
+msgid "Wrong country?"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:76
+msgid "Before"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:78
+msgid "After"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:89
+#, js-format
+msgid "%1$s — %2$d changes"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:120
+msgid "No numbers to preview on this page."
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:131
+#, js-format
+msgid "Page %d"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:140
+msgid "Previous"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:148
+#: resources/react/src/pages/Scheduled.jsx:1103
+msgid "Next"
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:164
+msgid "I've reviewed the changes above and I'm ready to apply them."
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:170
+msgid "A backup will be saved before any change is made."
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:184
+msgid "Starting..."
+msgstr ""
+
+#: resources/react/src/components/migration/PreviewStep.jsx:189
+msgid "Apply changes"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:47
+msgid "Nothing to check yet"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:48
+msgid "Looks like you don't have any stored phone numbers yet. Come back here once you have subscribers or user mobile data."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:52
+msgid "Your numbers are already in good shape."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:54
+#, js-format
+msgid "We checked %d records and they all use the international format. No action needed."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:58
+#, js-format
+msgid "We checked %d records"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:60
+#, js-format
+msgid "%d numbers need the country code. Everything else is already in good shape."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:85
+msgid "Your previous update had errors. Some records weren't updated. You can re-run to retry, revert to roll back, or clear the old backup if you've handled it manually."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:89
+#, js-format
+msgid "A backup from %s exists. Applying new changes will replace it."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:90
+msgid "a previous run"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:99
+msgid "Revert the old update first?"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:107
+msgid "Clear old backup"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:119
+#, js-format
+msgid "We're checking %d new data source since your last update."
+msgid_plural "We're checking %d new data sources since your last update."
+msgstr[0] ""
+msgstr[1] ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:133
+msgid "This is a large update. It may take 1-2 minutes to apply. Please don't close the tab while it's running."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:143
+msgid "Total reviewed"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:144
+msgid "Need update"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:145
+msgid "Already correct"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:156
+msgid "View by source"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:175
+#, js-format
+msgid "%d need update"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:179
+#, js-format
+msgid "%d already OK"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:198
+msgid "What kind of numbers need fixing?"
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:221
+#, js-format
+msgid "Using country code %s."
+msgstr ""
+
+#: resources/react/src/components/migration/ReviewStep.jsx:248
+msgid "Preview changes"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:38
+msgid "Key SMS Tools for Your Site"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:39
+msgid "WSMS Pro offers phone logins, two-factor authentication, scheduled and repeating messages, shorter Bitly URLs, and a Gutenberg block. It also integrates with WooCommerce, BuddyPress, Quform, Gravity Forms, Easy Digital Downloads, WP Job Manager, and WP Awesome Support."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:46
+msgid "Advanced WooCommerce SMS Features"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:47
+msgid "WooCommerce Pro boosts sales and support with SMS campaigns, abandoned cart reminders, phone verification at checkout, SMS login and registration, and local shipping notifications."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:54
+msgid "Send and Receive Messages"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:55
+msgid "Two-Way lets you view incoming texts in your dashboard, set keywords to trigger replies, allow customers to update orders via SMS, and let subscribers join or leave newsletters by texting."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:62
+msgid "Elementor Form SMS Alerts"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:63
+msgid "Link your Elementor Pro forms to WSMS and send text message alerts to you and your users whenever a form is submitted."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:70
+msgid "Keep Members Informed"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:71
+msgid "Send automatic text messages whenever important membership events happen, like new signups, payment confirmations, or membership cancellations, so everyone stays in the loop."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:78
+msgid "Booking SMS Notifications"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:79
+msgid "Send SMS messages whenever important booking events happen. Automatically notify users for new, approved, canceled, or rescheduled appointments."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:86
+msgid "Connect with Fluent"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:87
+msgid "Connect WSMS with Fluent CRM, Fluent Forms, and Fluent Support. Get real-time SMS notifications for new subscribers, form submissions, or support tickets."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:107
+msgid "You're All Set with WSMS All-in-One"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:108
+msgid "You already have the complete bundle! Enjoy every premium feature and integration with no extra steps. Thanks for your support — have fun exploring everything!"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:113
+msgid "You're Already Enjoying Add-Ons!"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:114
+msgid "Looks like you have a few premium features active. Upgrade to All-in-One to unlock every tool and integration. Get the most out of WSMS and boost your site's performance."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:118
+msgid "All Premium SMS Features in One Package"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:119
+msgid "All-in-One includes Pro, WooCommerce Pro, Two-Way, and more. Send better SMS, handle two-way messaging, secure logins, and manage everything in one place."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:152
+msgid "Not Activated"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:159
+msgid "No License"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:177
+msgid "Your license includes the"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:179
+msgid ", but it's not installed yet. Go to the Add-Ons page to install and"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:180
+msgid "activate"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:181
+msgid "it, so you can start using all its features."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:192
+msgid "This add-on does"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:193
+msgid "not have an active license"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:194
+msgid ", which means it cannot receive updates, including important security updates. For uninterrupted access to updates and to keep your site secure, we strongly recommend activating a license."
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:216
+msgid "All-in-One Activated"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:224
+msgid "Upgrade Now"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:229
+#: resources/react/src/components/modals/AllInOneModal.jsx:246
+#: resources/react/src/components/modals/AllInOneModal.jsx:281
+msgid "Maybe Later"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:256
+msgid "Go to Add-Ons Page"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:266
+msgid "Add-on Activated"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:396
+msgid "WSMS All-in-One"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:428
+msgid "Go to step"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:449
+msgid "Learn more"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:496
+msgid "All-in-One Includes"
+msgstr ""
+
+#: resources/react/src/components/modals/AllInOneModal.jsx:556
+msgid "Unlock all premium features with one license"
+msgstr ""
+
+#: resources/react/src/components/notifications/NotificationSidebar.jsx:248
+msgid "Notification tabs"
+msgstr ""
+
+#: resources/react/src/components/notifications/NotificationSidebar.jsx:283
+#, js-format
+msgid "Clear all %s notifications"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:42
+msgid "Intro"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:44
+msgid "Review"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:45
+#: resources/react/src/pages/MessageButton.jsx:452
+msgid "Preview"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:46
+msgid "Apply"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:47
+msgid "Done"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:75
+msgid "Your session has expired. Please reload the page to continue."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:82
+msgid "Server returned an invalid response."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:90
+msgid "An error occurred."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:232
+msgid "We couldn't confirm the update finished. The change may or may not have been applied."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:276
+msgid "We couldn't confirm the update finished. Please refresh this page and run the check again."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:327
+msgid "Restored"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:329
+#, js-format
+msgid "%d numbers restored to their original format."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:353
+msgid "Cleared"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:354
+msgid "The old backup was cleared."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:423
+msgid "Phone number check"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:425
+msgid "Get your numbers ready for reliable SMS delivery."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:461
+msgid "Another administrator started this update a few seconds ago. We'll check on it."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:544
+msgid "Undo this update?"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:546
+#, js-format
+msgid "We'll restore all %1$d numbers to their original format using the backup from %2$s. This replaces the current values — any changes made to those numbers since the update will be overwritten."
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:550
+msgid "the previous run"
+msgstr ""
+
+#: resources/react/src/components/NumberMigrationModal.jsx:552
+msgid "Yes, undo"
+msgstr ""
+
+#: resources/react/src/components/shared/AddonUpdateRequired.jsx:49
+msgid "Update Required"
+msgstr ""
+
+#: resources/react/src/components/shared/AddonUpdateRequired.jsx:52
+#, js-format
+msgid "The %s add-on needs to be updated to work with the new dashboard. Please update it to the latest version."
+msgstr ""
+
+#: resources/react/src/components/shared/AddonUpdateRequired.jsx:56
+msgid "Go to Plugins"
+msgstr ""
+
+#: resources/react/src/components/shared/DateRangePicker.jsx:41
+msgid "From date"
+msgstr ""
+
+#: resources/react/src/components/shared/DateRangePicker.jsx:50
+msgid "To date"
+msgstr ""
+
+#: resources/react/src/components/shared/DeleteConfirmDialog.jsx:48
+#: resources/react/src/pages/AddOns.jsx:199
+#: resources/react/src/pages/Gateway.jsx:526
+#: resources/react/src/pages/Gateway.jsx:545
+#: resources/react/src/pages/Groups.jsx:472
+#: resources/react/src/pages/Outbox.jsx:719
+#: resources/react/src/pages/Scheduled.jsx:674
+#: resources/react/src/pages/Scheduled.jsx:1274
+#: resources/react/src/pages/SmsCampaigns.jsx:467
+#: resources/react/src/pages/Subscribers.jsx:1129
+#: resources/react/src/pages/TwoWayCommands.jsx:570
+#: resources/react/src/pages/TwoWayInbox.jsx:774
+msgid "Cancel"
+msgstr ""
+
+#: resources/react/src/components/shared/DeleteConfirmDialog.jsx:54
+msgid "Deleting..."
+msgstr ""
+
+#: resources/react/src/components/shared/ExportButton.jsx:47
+msgid "Export failed"
+msgstr ""
+
+#: resources/react/src/components/shared/ExportButton.jsx:68
+msgid "Export"
+msgstr ""
+
+#: resources/react/src/components/shared/MediaSelector.jsx:39
+#: resources/react/src/components/shared/MediaSelector.jsx:177
+msgid "Select Media"
+msgstr ""
+
+#: resources/react/src/components/shared/MediaSelector.jsx:44
+msgid "Use this media"
+msgstr ""
+
+#: resources/react/src/components/shared/MediaSelector.jsx:77
+#: resources/react/src/components/shared/MediaSelector.jsx:120
+msgid "Selected media"
+msgstr ""
+
+#: resources/react/src/components/shared/MediaSelector.jsx:94
+#: resources/react/src/components/shared/MediaSelector.jsx:133
+msgid "Change"
+msgstr ""
+
+#: resources/react/src/components/shared/MediaSelector.jsx:103
+#: resources/react/src/components/shared/MediaSelector.jsx:140
+#: resources/react/src/components/shared/MediaSelector.jsx:160
+msgid "Remove media"
+msgstr ""
+
+#: resources/react/src/components/shared/MessageComposer.jsx:38
+#: resources/react/src/components/shared/MessageComposer.jsx:72
+msgid "Standard"
+msgstr ""
+
+#: resources/react/src/components/shared/MessageComposer.jsx:72
+msgid "Unicode"
+msgstr ""
+
+#: resources/react/src/components/shared/MessageComposer.jsx:126
+msgid "segment"
+msgstr ""
+
+#: resources/react/src/components/shared/MessageComposer.jsx:126
+msgid "segments"
+msgstr ""
+
+#: resources/react/src/components/shared/MessageComposer.jsx:145
+msgid "Your message contains Unicode characters. This reduces the character limit per segment from 160 to 70 characters."
+msgstr ""
+
+#: resources/react/src/components/shared/MessageComposer.jsx:154
+#, js-format
+msgid "Message exceeds maximum of %s segments. Please shorten your message."
+msgstr ""
+
+#: resources/react/src/components/shared/MessageComposer.jsx:161
+#, js-format
+msgid "%s characters remaining in current segment"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:11
+#: resources/react/src/lib/pageRegistry.js:94
+#: resources/react/src/pages/Groups.jsx:356
+#: resources/react/src/pages/Subscribers.jsx:585
+#: resources/react/src/pages/Subscribers.jsx:827
+msgid "Groups"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:11
+msgid "Subscriber groups"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:12
+msgid "Roles"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:12
+msgid "WordPress roles"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:13
+msgid "Users"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:13
+msgid "Individual users"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:14
+msgid "Manual entry"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:299
+#: resources/react/src/pages/Newsletter.jsx:76
+#: resources/react/src/pages/Subscribers.jsx:586
+#: resources/react/src/pages/Subscribers.jsx:828
+msgid "Search groups..."
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:299
+#: resources/react/src/pages/Notifications.jsx:178
+#: resources/react/src/pages/Notifications.jsx:333
+msgid "Search roles..."
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:300
+msgid "Search groups"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:300
+msgid "Search roles"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:315
+msgid "Search by name, email, or user ID..."
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:405
+msgid "No groups match your search"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:405
+msgid "No subscriber groups available"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:419
+msgid "No roles match your search"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:419
+msgid "No user roles available"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:466
+msgid "No users found"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:500
+msgid "No mobile number"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:505
+msgid "Selected"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:521
+msgid "users"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:521
+msgid "user"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:521
+msgid "selected"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:529
+#: resources/react/src/components/shared/RecipientSelector.jsx:612
+msgid "Clear"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:562
+msgid "Search for users above"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:579
+msgid "Enter phone number..."
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:590
+msgid "Add number"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:596
+msgid "Separate multiple with commas"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:604
+msgid "numbers"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:604
+msgid "number"
+msgstr ""
+
+#: resources/react/src/components/shared/RecipientSelector.jsx:641
+msgid "No numbers added"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:103
+#: resources/react/src/components/ui/data-table.jsx:511
+msgid "Actions"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:161
+msgid "Open menu"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:223
+msgid "Pagination"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:226
+msgid "Showing"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:226
+msgid "to"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:227
+#: resources/react/src/components/wizard/SetupWizard.jsx:361
+msgid "of"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:228
+msgid "results"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:233
+msgid "Per page"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:259
+msgid "Go to previous page"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:271
+#: resources/react/src/components/ui/data-table.jsx:289
+#: resources/react/src/components/ui/data-table.jsx:306
+#, js-format
+msgid "Go to page %s"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:320
+msgid "Go to next page"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:454
+#: resources/react/src/components/ui/searchable-select.jsx:175
+msgid "Search"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:468
+msgid "Select"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:473
+msgid "Select all"
+msgstr ""
+
+#: resources/react/src/components/ui/data-table.jsx:548
+#, js-format
+msgid "Select row %s"
+msgstr ""
+
+#: resources/react/src/components/ui/DynamicField.jsx:384
+#: resources/react/src/pages/SmsCampaigns.jsx:431
+msgid "Days"
+msgstr ""
+
+#: resources/react/src/components/ui/DynamicField.jsx:396
+#: resources/react/src/pages/SmsCampaigns.jsx:430
+msgid "Hours"
+msgstr ""
+
+#: resources/react/src/components/ui/DynamicField.jsx:409
+#: resources/react/src/pages/SmsCampaigns.jsx:429
+msgid "Minutes"
+msgstr ""
+
+#: resources/react/src/components/ui/repeater.jsx:272
+#: resources/react/src/pages/MessageButton.jsx:679
+msgid "Select..."
+msgstr ""
+
+#: resources/react/src/components/ui/repeater.jsx:287
+#: resources/react/src/pages/SendSms.jsx:374
+msgid "Select Image"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:96
+#: resources/react/src/components/wizard/WizardStepper.jsx:10
+msgid "Getting Started"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:98
+#: resources/react/src/components/wizard/WizardStepper.jsx:12
+#: resources/react/src/pages/Overview.jsx:306
+msgid "Configuration"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:99
+#: resources/react/src/components/wizard/WizardStepper.jsx:13
+msgid "Test Setup"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:106
+#: resources/react/src/components/wizard/WizardStepper.jsx:15
+msgid "Ready"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:326
+msgid "Finish"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:327
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:156
+msgid "Skip"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:358
+msgid "WSMS Setup Wizard"
+msgstr ""
+
+#: resources/react/src/components/wizard/SetupWizard.jsx:361
+msgid "Step"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:13
+#: resources/react/src/lib/pageRegistry.js:244
+#: resources/react/src/pages/TwoWaySettings.jsx:248
+msgid "Two-Way SMS"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:14
+msgid "Receive replies and create auto-responses"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:18
+#: resources/react/src/pages/Integrations.jsx:876
+#: resources/react/src/pages/PhoneConfig.jsx:110
+msgid "WooCommerce"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:19
+msgid "Order notifications & cart abandonment"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:23
+msgid "OTP & 2FA"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:24
+msgid "Secure login with SMS verification"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:28
+msgid "Automations"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:29
+msgid "Trigger SMS based on user actions"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:34
+msgid "Priority email support"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:35
+msgid "Regular updates and new features"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:36
+msgid "Access to premium gateways"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:37
+msgid "Detailed analytics and reports"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:50
+msgid "Unlock More with All-in-One"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:53
+msgid "Take your SMS communications to the next level with powerful features."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:87
+msgid "All All-in-One plans include:"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:113
+msgid "View Plans"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/AllInOneStep.jsx:118
+msgid "Skip for now"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:96
+msgid "Enter your API credentials to connect."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:115
+msgid "View Documentation"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:125
+msgid "Gateway Credentials"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:127
+msgid "Enter the credentials from your gateway provider."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:175
+msgid "Save your gateway selection first to load credential fields."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:181
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:191
+#: resources/react/src/pages/Gateway.jsx:764
+msgid "Test Connection"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:182
+#: resources/react/src/pages/Overview.jsx:169
+msgid "Verify credentials work"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:188
+#: resources/react/src/pages/Gateway.jsx:759
+#: resources/react/src/pages/Overview.jsx:287
+msgid "Testing..."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:204
+msgid "Connection successful!"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:207
+msgid "Balance:"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ConfigurationStep.jsx:216
+msgid "Connection failed. Check your credentials."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:18
+msgid "200+ Gateways"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:19
+msgid "Global Coverage"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:20
+msgid "Secure & Reliable"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:28
+msgid "Welcome to WSMS"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:31
+msgid "Let's get your SMS gateway configured in just a few steps."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:52
+msgid "Your Mobile Number"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:56
+msgid "We'll use this for test SMS and admin notifications."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/GettingStartedStep.jsx:70
+msgid "Valid phone number"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:32
+msgid "Send Your First SMS"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:33
+msgid "Start sending messages right away"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:39
+msgid "Configure Notifications"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:40
+msgid "Set up automatic SMS alerts"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:46
+msgid "Explore Settings"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:47
+msgid "Fine-tune your SMS configuration"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:67
+msgid "You're All Set!"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:70
+msgid "Your SMS gateway is configured and ready to use."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:80
+#: resources/react/src/pages/Overview.jsx:157
+msgid "Connected to"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:89
+msgid "What would you like to do next?"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:149
+msgid "Completing..."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/ReadyStep.jsx:152
+msgid "Close Setup Wizard"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/SmsGatewayStep.jsx:19
+msgid "Choose Your SMS Gateway"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/SmsGatewayStep.jsx:22
+msgid "Select your SMS provider from 200+ supported gateways."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/SmsGatewayStep.jsx:32
+msgid "Search and select your gateway provider."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:28
+msgid "Failed to send test SMS"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:50
+msgid "Test Your Setup"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:53
+msgid "Send a test message to verify everything works."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:61
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:93
+msgid "Send Test SMS"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:63
+msgid "A test message will be sent to your phone."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:70
+msgid "Sending to"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:72
+msgid "No number"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:88
+#: resources/react/src/pages/Outbox.jsx:725
+#: resources/react/src/pages/TwoWayInbox.jsx:780
+msgid "Sending..."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:112
+msgid "Test SMS sent! Did you receive it?"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:117
+#: resources/react/src/pages/CartAbandonment.jsx:131
+msgid "Yes"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:121
+#: resources/react/src/pages/CartAbandonment.jsx:136
+msgid "No"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:132
+msgid "Perfect!"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:133
+msgid "Your gateway is working correctly."
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:142
+msgid "Troubleshooting:"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:144
+msgid "Check phone signal"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:145
+msgid "Verify phone number"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:146
+msgid "Wait a few minutes"
+msgstr ""
+
+#: resources/react/src/components/wizard/steps/TestSetupStep.jsx:147
+msgid "Check gateway account"
+msgstr ""
+
+#: resources/react/src/hooks/useFormDialog.js:175
+msgid "Updated successfully"
+msgstr ""
+
+#: resources/react/src/hooks/useFormDialog.js:176
+msgid "Created successfully"
+msgstr ""
+
+#: resources/react/src/hooks/useFormDialog.js:195
+msgid "Failed to save"
+msgstr ""
+
+#: resources/react/src/hooks/useListPage.js:48
+msgid "Deleted successfully"
+msgstr ""
+
+#: resources/react/src/hooks/useListPage.js:50
+#: resources/react/src/pages/Outbox.jsx:62
+#: resources/react/src/pages/Scheduled.jsx:75
+#: resources/react/src/pages/Scheduled.jsx:708
+msgid "Action completed successfully"
+msgstr ""
+
+#: resources/react/src/hooks/useListPage.js:51
+msgid "Action failed"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:79
+msgid "Scheduled"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:102
+msgid "Privacy"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:111
+#: resources/react/src/pages/AddOns.jsx:357
+msgid "Add-Ons"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:119
+msgid "Overview"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:131
+#: resources/react/src/pages/CartAbandonment.jsx:104
+msgid "Phone"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:149
+msgid "Authentication"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:156
+#: resources/react/src/pages/Overview.jsx:146
+msgid "Newsletter"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:168
+#: resources/react/src/pages/Overview.jsx:148
+msgid "Advanced"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:176
+#: resources/react/src/pages/SmsCampaigns.jsx:794
+msgid "SMS Campaigns"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:183
+#: resources/react/src/pages/CartAbandonment.jsx:288
+msgid "Cart Abandonment"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:199
+msgid "Inbox"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:206
+msgid "Commands"
+msgstr ""
+
+#: resources/react/src/lib/pageRegistry.js:237
+msgid "WooCommerce Pro"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:63
+#: resources/react/src/lib/tableColumns.jsx:427
+#: resources/react/src/pages/Scheduled.jsx:331
+#: resources/react/src/pages/Scheduled.jsx:406
+#: resources/react/src/pages/Scheduled.jsx:506
+#: resources/react/src/pages/SmsCampaigns.jsx:63
+#: resources/react/src/pages/SmsCampaigns.jsx:285
+#: resources/react/src/pages/SmsCampaigns.jsx:841
+msgid "Pending"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:112
+#: resources/react/src/pages/Outbox.jsx:627
+#: resources/react/src/pages/Scheduled.jsx:546
+#: resources/react/src/pages/Scheduled.jsx:1133
+#: resources/react/src/pages/SendSms.jsx:361
+msgid "Media"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:178
+#: resources/react/src/lib/tableColumns.jsx:415
+#: resources/react/src/lib/tableColumns.jsx:541
+msgid "recipients"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:190
+#: resources/react/src/lib/tableColumns.jsx:418
+#: resources/react/src/lib/tableColumns.jsx:544
+msgid "From:"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:220
+#: resources/react/src/pages/Outbox.jsx:685
+#: resources/react/src/pages/Subscribers.jsx:460
+#: resources/react/src/pages/TwoWayInbox.jsx:739
+msgid "Quick Reply"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:227
+#: resources/react/src/pages/Outbox.jsx:673
+msgid "Resend"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:249
+#: resources/react/src/lib/tableColumns.jsx:376
+#: resources/react/src/lib/tableColumns.jsx:475
+#: resources/react/src/lib/tableColumns.jsx:604
+#: resources/react/src/pages/Outbox.jsx:266
+#: resources/react/src/pages/Outbox.jsx:769
+#: resources/react/src/pages/Scheduled.jsx:207
+#: resources/react/src/pages/Scheduled.jsx:615
+#: resources/react/src/pages/Scheduled.jsx:808
+#: resources/react/src/pages/Scheduled.jsx:1196
+#: resources/react/src/pages/Subscribers.jsx:490
+#: resources/react/src/pages/Subscribers.jsx:511
+#: resources/react/src/pages/Subscribers.jsx:1175
+#: resources/react/src/pages/TwoWayInbox.jsx:301
+#: resources/react/src/pages/TwoWayInbox.jsx:429
+#: resources/react/src/pages/TwoWayInbox.jsx:917
+msgid "Delete Selected"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:255
+#: resources/react/src/pages/Outbox.jsx:273
+msgid "Resend Selected"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:299
+msgid "No group"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:331
+#: resources/react/src/pages/Subscribers.jsx:447
+msgid "Subscribed"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:345
+#: resources/react/src/lib/tableColumns.jsx:447
+#: resources/react/src/lib/tableColumns.jsx:582
+#: resources/react/src/pages/Groups.jsx:249
+#: resources/react/src/pages/SmsCampaigns.jsx:559
+#: resources/react/src/pages/SmsCampaigns.jsx:1016
+#: resources/react/src/pages/Subscribers.jsx:465
+#: resources/react/src/pages/TwoWayCommands.jsx:315
+msgid "Edit"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:355
+msgid "Toggle Status"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:405
+#: resources/react/src/pages/Scheduled.jsx:638
+msgid "Scheduled Date"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:453
+#: resources/react/src/pages/Scheduled.jsx:577
+msgid "Send Now"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:481
+#: resources/react/src/pages/Scheduled.jsx:237
+msgid "Send Selected Now"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:499
+msgid "Interval"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:502
+msgid "minute"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:502
+msgid "minutes"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:503
+msgid "hour"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:503
+msgid "hours"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:504
+msgid "day"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:504
+msgid "days"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:505
+msgid "week"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:505
+msgid "weeks"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:506
+msgid "month"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:506
+msgid "months"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:512
+msgid "Every"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:521
+msgid "Next Occurrence"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:527
+msgid "Ends At"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:530
+msgid "Never"
+msgstr ""
+
+#: resources/react/src/lib/tableColumns.jsx:564
+#: resources/react/src/pages/Scheduled.jsx:952
+#: resources/react/src/pages/Scheduled.jsx:998
+#: resources/react/src/pages/Scheduled.jsx:1088
+msgid "Ended"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:52
+msgid "Failed to activate license."
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:64
+msgid "Failed to remove license."
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:105
+msgid "Update Available"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:130
+msgid "Expired"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:141
+msgid "Update license"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:149
+msgid "Remove license"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:170
+#: resources/react/src/pages/AddOns.jsx:171
+msgid "Enter new license key"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:170
+#: resources/react/src/pages/AddOns.jsx:171
+msgid "Enter license key"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:217
+msgid "Details"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:217
+msgid "Get Add-On"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:228
+msgid "Docs"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:239
+msgid "Changelog"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:298
+msgid "Failed to load add-ons."
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:322
+msgid "Unable to load add-ons"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:336
+msgid "No add-ons available"
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:337
+msgid "Add-ons extend WSMS with extra features. Check back later for available add-ons."
+msgstr ""
+
+#: resources/react/src/pages/AddOns.jsx:360
+msgid "Manage add-ons to extend WSMS functionality"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:46
+msgid "Webhooks"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:49
+msgid "Integrate with external services via webhook notifications"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:61
+msgid "Called after each SMS is sent. Enter one URL per line."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:66
+msgid "New Subscriber Webhook"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:75
+msgid "Called when someone subscribes to your SMS newsletter."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:80
+msgid "Incoming SMS Webhook"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:89
+msgid "Called when you receive an SMS reply. Requires Two-Way SMS add-on."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:100
+#: resources/react/src/pages/TwoWaySettings.jsx:440
+msgid "Message Storage"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:103
+msgid "Configure message logging and automatic cleanup"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:108
+msgid "Log Sent Messages"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:109
+msgid "Save all sent SMS messages in the Outbox for tracking."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:116
+msgid "Auto-delete Sent Messages"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:119
+msgid "Select retention period"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:120
+msgid "Automatically remove old messages from the Outbox."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:122
+msgid "After 30 days"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:123
+msgid "After 90 days"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:124
+msgid "After 180 days"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:125
+msgid "After 365 days"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:141
+msgid "Configure email reports about SMS performance and errors"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:146
+msgid "Weekly Statistics Email"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:147
+msgid "Receive weekly SMS usage reports via email."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:153
+msgid "Error Notifications"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:154
+msgid "Email admin when SMS sending fails."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:169
+msgid "Manage plugin update notices and announcements"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:174
+msgid "WSMS Notifications"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:175
+msgid "Show update notices and announcements in the admin area."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:190
+msgid "Help improve WSMS by sharing anonymous usage statistics"
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:196
+msgid "Share non-personal, anonymized data to help improve WSMS."
+msgstr ""
+
+#: resources/react/src/pages/Advanced.jsx:234
+msgid "Additional Add-on Settings"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:46
+msgid "Not Scheduled"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:51
+msgid "Not Sent"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:56
+#: resources/react/src/pages/SmsCampaigns.jsx:1076
+#: resources/react/src/pages/SmsCampaigns.jsx:1121
+msgid "In Queue"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:89
+msgid "Customer"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:96
+#: resources/react/src/pages/CartAbandonment.jsx:510
+msgid "Guest"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:115
+msgid "Cart Total"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:126
+#: resources/react/src/pages/CartAbandonment.jsx:354
+msgid "Recovered"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:143
+#: resources/react/src/pages/SmsCampaigns.jsx:1113
+msgid "SMS Status"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:209
+#: resources/react/src/pages/TwoWaySettings.jsx:75
+#: resources/react/src/pages/TwoWaySettings.jsx:105
+#: resources/react/src/pages/TwoWaySettings.jsx:139
+msgid "Error"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:210
+msgid "Failed to load cart abandonment data"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:233
+msgid "Cart deleted successfully"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:245
+msgid "Failed to delete cart"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:291
+msgid "Recover abandoned carts with automated SMS reminders."
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:297
+#: resources/react/src/pages/SmsCampaigns.jsx:751
+msgid "WooCommerce Pro Add-on Required"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:299
+msgid "Install and activate the WSMS WooCommerce Pro add-on to access Cart Abandonment features."
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:341
+msgid "Recoverable"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:367
+msgid "Recoverable Revenue"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:380
+msgid "Recovered Revenue"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:406
+msgid "Following SMS"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:421
+msgid "Search by phone..."
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:422
+msgid "Search abandoned carts"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:435
+msgid "Filter by type"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:436
+#: resources/react/src/pages/CartAbandonment.jsx:439
+msgid "All Carts"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:440
+msgid "Abandoned Only"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:441
+msgid "Recovered Only"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:449
+msgid "Filter by duration"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:450
+#: resources/react/src/pages/CartAbandonment.jsx:453
+msgid "All Time"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:456
+msgid "Last Week"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:457
+msgid "Last Month"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:470
+#: resources/react/src/pages/SmsCampaigns.jsx:864
+msgid "Refresh"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:490
+msgid "No abandoned carts found"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:502
+msgid "Delete Abandoned Cart"
+msgstr ""
+
+#: resources/react/src/pages/CartAbandonment.jsx:503
+msgid "Are you sure you want to delete this abandoned cart record? This action cannot be undone."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:280
+msgid "Need help choosing a gateway?"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:280
+msgid "Consider factors like coverage area, pricing, and API features. Most gateways offer free trial credits to test before committing."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:291
+msgid "Select your SMS service provider. Configure credentials below after selecting."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:300
+msgid "Search gateways"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:376
+msgid "Development"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:485
+msgid "Selected Gateway"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:503
+msgid "Visit Website"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:511
+msgid "Switch to"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:520
+msgid "Switch"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:531
+msgid "Are you sure?"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:539
+#: resources/react/src/pages/Gateway.jsx:554
+msgid "Disconnect"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:562
+msgid "Save your changes to see capabilities and configure credentials for this gateway."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:567
+msgid "Capabilities:"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:575
+#: resources/react/src/pages/SendSms.jsx:339
+msgid "Flash SMS"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:582
+msgid "Bulk Send"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:589
+msgid "MMS"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:596
+msgid "Incoming SMS"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:610
+#: resources/react/src/pages/Overview.jsx:240
+#: resources/react/src/pages/TwoWaySettings.jsx:236
+msgid "No Gateway Selected"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:613
+msgid "Choose a provider from the list above"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:633
+msgid "Setup instructions for"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:661
+msgid "View Full Documentation"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:675
+msgid "Credentials"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:677
+msgid "API credentials for"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:769
+msgid "Verify your credentials are working"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:778
+msgid "Raw response from the gateway for debugging"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:784
+msgid "Gateway Response:"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:801
+msgid "Delivery Settings"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:804
+msgid "Configure how messages are processed and delivered"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:813
+msgid "Select method"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:823
+msgid "Queue mode requires a cron job to process messages. Configure WP-Cron or set up a real cron job for reliable delivery."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:827
+msgid "Message Formatting"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:831
+msgid "Enable Unicode"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:832
+msgid "Required for non-Latin characters (Arabic, Chinese, emoji). May reduce characters per SMS."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:838
+msgid "Auto-format Numbers"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:839
+msgid "Automatically remove spaces and special characters from phone numbers before sending."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:846
+msgid "Country Restrictions"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:850
+msgid "Restrict to Specific Countries"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:851
+msgid "Only send SMS to phone numbers from selected countries."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:860
+msgid "Allowed Countries"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:864
+msgid "Select countries..."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:865
+#: resources/react/src/pages/PhoneConfig.jsx:213
+#: resources/react/src/pages/PhoneConfig.jsx:223
+#: resources/react/src/pages/PhoneConfig.jsx:238
+#: resources/react/src/pages/Subscribers.jsx:747
+msgid "Search countries..."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:866
+msgid "SMS will only be sent to numbers from these countries."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:877
+msgid "Credit Display"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:883
+msgid "Show Credit in Menu"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:884
+msgid "Display your SMS credit balance in the WordPress admin menu bar."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:890
+msgid "Show Credit on Send Page"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:891
+msgid "Display your remaining SMS credits when composing messages."
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:905
+msgid "Setup Wizard"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:908
+msgid "Re-run the guided setup to update your gateway configuration"
+msgstr ""
+
+#: resources/react/src/pages/Gateway.jsx:917
+msgid "Re-run Wizard"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:176
+msgid "Group Name"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:191
+#: resources/react/src/pages/Groups.jsx:460
+msgid "Edit group name"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:200
+msgid "Save group name"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:214
+msgid "Cancel editing"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:278
+msgid "Failed to load groups"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:305
+msgid "Create your first group"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:308
+msgid "Groups help you organize subscribers for targeted messaging. Segment your audience by interest, location, or any criteria that matters to your communication."
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:313
+msgid "Enter group name..."
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:314
+#: resources/react/src/pages/Groups.jsx:408
+msgid "Create Group"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:318
+#: resources/react/src/pages/Groups.jsx:412
+msgid "Group name must be at least 2 characters"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:319
+#: resources/react/src/pages/Groups.jsx:413
+msgid "Group name must be less than 50 characters"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:328
+msgid "Targeted Messaging"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:329
+msgid "Send SMS to specific groups only"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:333
+msgid "Easy Organization"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:334
+msgid "Manage subscribers efficiently"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:366
+msgid "Total Subscribers"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:380
+msgid "List view"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:391
+msgid "Grid view"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:407
+msgid "Enter group name to create..."
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:485
+msgid "Save"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:575
+#: resources/react/src/pages/Groups.jsx:577
+msgid "Delete Group"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:576
+msgid "Are you sure you want to delete"
+msgstr ""
+
+#: resources/react/src/pages/Groups.jsx:581
+msgid "This will remove the group but keep all subscribers. They will become ungrouped."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:147
+#: resources/react/src/pages/Integrations.jsx:325
+#: resources/react/src/pages/Integrations.jsx:504
+#: resources/react/src/pages/Integrations.jsx:680
+msgid "Phone numbers"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:199
+#: resources/react/src/pages/Integrations.jsx:377
+#: resources/react/src/pages/Integrations.jsx:556
+#: resources/react/src/pages/Integrations.jsx:732
+msgid "Form field"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:200
+#: resources/react/src/pages/Integrations.jsx:378
+#: resources/react/src/pages/Integrations.jsx:557
+#: resources/react/src/pages/Integrations.jsx:733
+msgid "Select a field..."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:871
+#: resources/react/src/pages/Integrations.jsx:872
+#: resources/react/src/pages/Integrations.jsx:873
+msgid "Free"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:872
+#: resources/react/src/pages/Integrations.jsx:982
+msgid "Formidable Forms"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:874
+#: resources/react/src/pages/Integrations.jsx:1072
+msgid "Gravity Forms"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:874
+#: resources/react/src/pages/Integrations.jsx:875
+#: resources/react/src/pages/Integrations.jsx:876
+#: resources/react/src/pages/Integrations.jsx:877
+#: resources/react/src/pages/Integrations.jsx:878
+#: resources/react/src/pages/Integrations.jsx:879
+#: resources/react/src/pages/Integrations.jsx:880
+#: resources/react/src/pages/Integrations.jsx:881
+msgid "Requires WSMS PRO"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:875
+#: resources/react/src/pages/Integrations.jsx:1116
+msgid "Quform"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:877
+msgid "BuddyPress"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:878
+msgid "Easy Digital Downloads"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:879
+msgid "WP Job Manager"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:880
+msgid "Awesome Support"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:881
+msgid "Ultimate Member"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:882
+msgid "Elementor Forms"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:882
+msgid "Requires Elementor add-on"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:883
+msgid "Fluent CRM"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:883
+#: resources/react/src/pages/Integrations.jsx:884
+#: resources/react/src/pages/Integrations.jsx:885
+msgid "Requires Fluent add-on"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:884
+#: resources/react/src/pages/Integrations.jsx:1160
+msgid "Fluent Forms"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:885
+msgid "Fluent Support"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:886
+msgid "Paid Memberships Pro"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:886
+#: resources/react/src/pages/Integrations.jsx:887
+msgid "Requires Membership add-on"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:887
+msgid "Simple Membership"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:888
+msgid "BookingPress"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:888
+#: resources/react/src/pages/Integrations.jsx:889
+#: resources/react/src/pages/Integrations.jsx:890
+#: resources/react/src/pages/Integrations.jsx:891
+msgid "Requires Booking add-on"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:889
+msgid "WooCommerce Appointments"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:890
+msgid "WooCommerce Bookings"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:891
+msgid "Booking Calendar"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:934
+msgid "Send SMS notifications when Contact Form 7 forms are submitted"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:949
+#: resources/react/src/pages/Integrations.jsx:955
+#: resources/react/src/pages/Integrations.jsx:1000
+#: resources/react/src/pages/Integrations.jsx:1006
+msgid "SMS Notification Tab"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:951
+msgid "Add an SMS notification settings tab to each Contact Form 7 form editor."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:985
+msgid "Send SMS notifications when Formidable forms are submitted"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1002
+msgid "Add an SMS notification settings tab to each Formidable form editor."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1031
+msgid "Send SMS notifications when Forminator forms are submitted"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1052
+msgid "No forms found. Create a form in Forminator to configure SMS notifications."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1075
+msgid "Send SMS notifications when Gravity Forms are submitted"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1096
+msgid "No forms found. Create a form in Gravity Forms to configure SMS notifications."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1119
+msgid "Send SMS notifications when Quform forms are submitted"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1140
+msgid "No forms found. Create a form in Quform to configure SMS notifications."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1163
+msgid "Send SMS notifications when Fluent Forms are submitted"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1184
+msgid "No forms found. Create a form in Fluent Forms to configure SMS notifications."
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1208
+msgid "Additional Settings"
+msgstr ""
+
+#: resources/react/src/pages/Integrations.jsx:1227
+msgid "All supported plugins and integrations"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:210
+#: resources/react/src/pages/MessageButton.jsx:494
+msgid "Chat with us"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:442
+msgid "Display a floating message button on your website for quick communication"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:458
+msgid "Enable Message Button"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:459
+msgid "Show a floating chat button on your website for visitor inquiries."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:466
+msgid "Chat Window Title"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:469
+msgid "How can we help?"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:470
+msgid "Heading shown when the chat window opens."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:486
+msgid "Customize how the message button looks and where it appears"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:491
+msgid "Button Label"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:495
+msgid "Text shown on the floating button."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:502
+msgid "Select style"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:512
+msgid "Button Position"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:515
+msgid "Select position"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:516
+msgid "Where the button appears on screen."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:524
+msgid "Open Animation"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:527
+msgid "Select animation"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:528
+msgid "How the chat window appears when opened."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:543
+msgid "Colors"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:546
+msgid "Customize the chatbox color scheme"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:552
+msgid "Primary Color"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:565
+msgid "Primary color hex value"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:569
+msgid "Background color for the button and chat header."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:574
+msgid "Text Color"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:587
+msgid "Text color hex value"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:591
+msgid "Text color for the button and header."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:603
+msgid "Footer Settings"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:606
+msgid "Customize the chatbox footer area"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:611
+msgid "Footer Message"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:614
+msgid "We typically reply within minutes"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:615
+msgid "Optional message shown at the bottom of the chat window."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:632
+msgid "Footer text color hex value"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:639
+msgid "Footer Link Text"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:642
+msgid "View FAQ"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:653
+msgid "Hide WSMS Branding"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:654
+msgid "Remove the \"Powered by WSMS\" text from the footer."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:666
+msgid "Support Team"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:669
+msgid "Add team members that visitors can contact directly."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:677
+msgid "Jane Smith"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:678
+msgid "Customer Support"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:684
+msgid "Email"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:687
+msgid "Available 9AM-5PM"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:688
+msgid "Avatar"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:688
+msgid "Select Avatar"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:690
+msgid "Add Team Member"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:692
+msgid "No team members added yet."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:705
+msgid "Add helpful resource links to the chatbox"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:710
+msgid "Show Quick Links"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:711
+msgid "Display helpful links in the chat window."
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:719
+msgid "Links Section Title"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:722
+msgid "Helpful Resources"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:731
+msgid "FAQ"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:732
+msgid "URL"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:734
+msgid "Add Link"
+msgstr ""
+
+#: resources/react/src/pages/MessageButton.jsx:736
+msgid "No links added. Add links to help visitors find answers quickly."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:50
+msgid "Configure how visitors subscribe to your SMS notifications"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:55
+msgid "Show Groups in Form"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:56
+msgid "Let subscribers choose which groups to join."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:64
+msgid "Allow Multiple Group Selection"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:71
+msgid "Available Groups"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:75
+msgid "All groups"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:77
+msgid "Which groups subscribers can choose from. Leave empty for all groups."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:82
+msgid "Default Group"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:86
+msgid "Automatically add new subscribers to this group."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:97
+msgid "Require SMS Verification"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:98
+msgid "Subscribers must verify their phone number via SMS code."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:110
+msgid "Welcome SMS"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:113
+msgid "Set up automatic SMS messages for new subscribers"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:118
+msgid "Send Welcome Message"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:119
+msgid "Automatically send a welcome SMS to new subscribers."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:126
+#: resources/react/src/pages/Notifications.jsx:283
+msgid "Welcome Message"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:131
+msgid "Welcome to our newsletter! Thanks for subscribing."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:145
+msgid "Form Appearance"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:148
+msgid "Customize the look of your subscription form"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:153
+msgid "Disable Default Styles"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:154
+msgid "Remove plugin CSS to use your own form styling."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:167
+msgid "GDPR Settings"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:170
+msgid "Configure privacy consent for newsletter subscriptions"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:175
+msgid "Consent Message"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:180
+msgid "I agree to receive SMS notifications and understand that my data will be handled according to the privacy policy."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:184
+msgid "Privacy consent text shown to subscribers. Required for GDPR compliance."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:189
+msgid "Checkbox Default State"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:192
+msgid "Select default state"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:193
+msgid "Must be unchecked by default for GDPR compliance."
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:195
+msgid "Checked"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:196
+msgid "Unchecked"
+msgstr ""
+
+#: resources/react/src/pages/Newsletter.jsx:207
+msgid "To enable GDPR settings for newsletters, first enable \"GDPR Compliance Enhancements\" in the Phone Configuration page."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:107
+msgid "New Content Notifications"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:108
+msgid "Send SMS when you publish new posts or pages."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:113
+#: resources/react/src/pages/Notifications.jsx:228
+msgid "Content Types"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:117
+#: resources/react/src/pages/Notifications.jsx:232
+msgid "All post types"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:118
+#: resources/react/src/pages/Notifications.jsx:233
+msgid "Search post types..."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:119
+msgid "Which content types trigger notifications."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:123
+msgid "Categories & Tags"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:127
+msgid "All taxonomies"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:128
+msgid "Search categories, tags..."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:129
+msgid "Only notify for content in these categories or with these tags. Leave empty for all."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:133
+msgid "Send To"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:136
+msgid "Select recipients"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:137
+msgid "Who should receive these notifications."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:140
+#: resources/react/src/pages/Notifications.jsx:163
+msgid "Phone Numbers"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:152
+#: resources/react/src/pages/Subscribers.jsx:718
+#: resources/react/src/pages/Subscribers.jsx:721
+msgid "All Groups"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:167
+msgid "Enter phone numbers, separated by commas."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:177
+msgid "Select user roles..."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:179
+msgid "Notify users with these roles."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:184
+msgid "Auto-send"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:185
+msgid "Send automatically when publishing (no confirmation prompt)."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:191
+msgid "Include Featured Image"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:192
+msgid "Send as MMS with the post's featured image (if gateway supports MMS)."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:198
+#: resources/react/src/pages/Notifications.jsx:238
+#: resources/react/src/pages/Notifications.jsx:307
+#: resources/react/src/pages/Notifications.jsx:338
+#: resources/react/src/pages/TwoWaySettings.jsx:414
+msgid "Message Template"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:203
+msgid "New post: %post_title% - Read more: %post_url%"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:210
+msgid "Content Word Limit"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:215
+msgid "Maximum words to include from post content in %post_content%."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:222
+msgid "Author Notifications"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:223
+msgid "Notify post authors when their content is published."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:234
+msgid "Which content types trigger author notifications."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:243
+msgid "Your post '%post_title%' has been published!"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:253
+msgid "WordPress Updates"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:254
+msgid "Get SMS alerts when a new WordPress version is available."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:262
+msgid "New User Alerts"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:263
+msgid "Send SMS when someone registers on your site."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:268
+msgid "Admin Notification"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:273
+#, js-format
+msgid "New user registered: %user_login% (%user_email%)"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:278
+msgid "Sent to admin."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:288
+#, js-format
+msgid "Welcome %first_name%! Your account has been created."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:293
+msgid "Sent to new user."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:301
+msgid "New Comment Alerts"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:302
+msgid "Get SMS when someone comments on your content."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:312
+#, js-format
+msgid "New comment on '%comment_post_title%' by %comment_author%"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:322
+msgid "Login Alerts"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:323
+msgid "Get SMS when users log into your site."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:328
+msgid "Monitor Roles"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:332
+msgid "All user roles"
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:334
+msgid "Only notify when users with these roles log in."
+msgstr ""
+
+#: resources/react/src/pages/Notifications.jsx:343
+#, js-format
+msgid "User %user_login% logged in"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:154
+#, js-format
+msgid "Cannot resend. %d %s outside your allowed countries. You can update this in Gateway > Country Restrictions."
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:154
+msgid "recipient is"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:154
+msgid "recipients are"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:166
+msgid "Failed to resend message"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:185
+#: resources/react/src/pages/Scheduled.jsx:812
+#, js-format
+msgid "%d message(s) deleted successfully"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:187
+#, js-format
+msgid "%d message(s) resent successfully"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:193
+#: resources/react/src/pages/Scheduled.jsx:196
+#: resources/react/src/pages/Scheduled.jsx:818
+msgid "Bulk action failed"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:217
+#: resources/react/src/pages/SendSms.jsx:189
+msgid "All recipients are outside your allowed countries. You can update this in Gateway > Country Restrictions."
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:231
+#, js-format
+msgid "Reply sent to %d1 recipient(s). %d2 skipped — their country codes don't match your country restriction settings."
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:235
+#: resources/react/src/pages/TwoWayInbox.jsx:167
+msgid "Reply sent successfully"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:241
+#: resources/react/src/pages/TwoWayInbox.jsx:172
+#: resources/react/src/pages/TwoWayInbox.jsx:231
+msgid "Failed to send reply"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:299
+#: resources/react/src/pages/TwoWayInbox.jsx:116
+msgid "Failed to load messages"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:333
+msgid "No messages yet"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:336
+msgid "When you send SMS messages, they will appear here. You can track delivery status, resend failed messages, and export your history."
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:339
+msgid "Go to"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:346
+msgid "to send your first message!"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:369
+msgid "Total Messages"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:442
+msgid "Rate"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:451
+#: resources/react/src/pages/TwoWayInbox.jsx:544
+#, js-format
+msgid "Exported %d messages successfully"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:472
+#: resources/react/src/pages/Scheduled.jsx:390
+#: resources/react/src/pages/Scheduled.jsx:981
+#: resources/react/src/pages/TwoWayInbox.jsx:561
+msgid "Search messages..."
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:474
+#: resources/react/src/pages/TwoWayInbox.jsx:563
+msgid "Search messages"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:483
+#: resources/react/src/pages/Scheduled.jsx:401
+#: resources/react/src/pages/Scheduled.jsx:992
+#: resources/react/src/pages/SmsCampaigns.jsx:834
+#: resources/react/src/pages/Subscribers.jsx:731
+#: resources/react/src/pages/TwoWayCommands.jsx:709
+msgid "Filter by status"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:487
+#: resources/react/src/pages/Scheduled.jsx:405
+#: resources/react/src/pages/Scheduled.jsx:996
+#: resources/react/src/pages/Subscribers.jsx:735
+#: resources/react/src/pages/TwoWayCommands.jsx:710
+#: resources/react/src/pages/TwoWayCommands.jsx:713
+msgid "All Status"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:508
+#: resources/react/src/pages/Scheduled.jsx:427
+#: resources/react/src/pages/Scheduled.jsx:1009
+#: resources/react/src/pages/SmsCampaigns.jsx:852
+#: resources/react/src/pages/Subscribers.jsx:769
+#: resources/react/src/pages/TwoWayCommands.jsx:742
+#: resources/react/src/pages/TwoWayInbox.jsx:614
+msgid "Clear all filters"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:520
+#: resources/react/src/pages/Scheduled.jsx:439
+#: resources/react/src/pages/Scheduled.jsx:1021
+#: resources/react/src/pages/TwoWayInbox.jsx:626
+msgid "Refresh messages"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:561
+#: resources/react/src/pages/TwoWayInbox.jsx:659
+msgid "No messages match your filters"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:573
+#: resources/react/src/pages/TwoWayInbox.jsx:671
+msgid "Message Details"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:576
+msgid "Sent on"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:608
+#: resources/react/src/pages/Scheduled.jsx:527
+#: resources/react/src/pages/Scheduled.jsx:1114
+msgid "Recipient(s)"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:653
+msgid "Gateway Response"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:687
+msgid "Send a quick reply to the recipient(s)"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:710
+msgid "Type your reply message..."
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:730
+#: resources/react/src/pages/TwoWayInbox.jsx:782
+msgid "Send Reply"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:744
+#: resources/react/src/pages/TwoWayInbox.jsx:897
+msgid "Delete Message"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:745
+#: resources/react/src/pages/TwoWayInbox.jsx:898
+msgid "Are you sure you want to delete this message?"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:770
+#: resources/react/src/pages/TwoWayInbox.jsx:918
+msgid "Delete Messages"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:771
+#: resources/react/src/pages/TwoWayInbox.jsx:919
+msgid "Are you sure you want to delete the selected messages?"
+msgstr ""
+
+#: resources/react/src/pages/Outbox.jsx:775
+#: resources/react/src/pages/Scheduled.jsx:621
+#: resources/react/src/pages/Scheduled.jsx:1202
+#: resources/react/src/pages/TwoWayInbox.jsx:923
+#, js-format
+msgid "%d message(s) will be permanently deleted."
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:95
+msgid "Connection Successful"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:96
+#: resources/react/src/pages/Overview.jsx:256
+msgid "Credit:"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:96
+msgid "Gateway is working correctly"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:101
+#: resources/react/src/pages/Overview.jsx:112
+msgid "Connection Failed"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:102
+#: resources/react/src/pages/Overview.jsx:113
+msgid "Could not connect to gateway"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:124
+msgid "Not configured"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:129
+msgid "Admin Mobile"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:131
+msgid "Not set"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:156
+msgid "Configure SMS Gateway"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:157
+msgid "Select your SMS provider"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:162
+msgid "Set Admin Mobile Number"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:163
+msgid "Add your phone for test messages"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:168
+msgid "Test Your Connection"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:169
+msgid "Gateway is working"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:186
+msgid "Welcome to WSMS!"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:189
+msgid "Complete these steps to start sending SMS messages from your WordPress site."
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:203
+#: resources/react/src/pages/TwoWaySettings.jsx:233
+msgid "Gateway Status"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:205
+msgid "Current SMS gateway connection"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:253
+msgid "Connected"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:263
+msgid "Connection failed"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:266
+msgid "Click to test"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:270
+msgid "Configure a gateway to send SMS"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:292
+msgid "Test"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:308
+msgid "Quick access to main settings"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:349
+msgid "SMS Gateways Available"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:352
+msgid "Providers from around the world"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:356
+msgid "Browse"
+msgstr ""
+
+#: resources/react/src/pages/Overview.jsx:374
+msgid "OTP authentication, WooCommerce integration, and more"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:61
+msgid "Receives system notifications (new users, comments, errors)."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:66
+msgid "Admin Phone Number"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:78
+msgid "Enter the full phone number including country code."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:93
+msgid "Choose where to collect mobile numbers from users."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:98
+msgid "Collect Phone Numbers From"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:100
+msgid "Collect phone numbers from"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:101
+msgid "Select source"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:104
+msgid "Don't collect — No mobile field"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:107
+msgid "Add field to user profiles"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:111
+msgid "Add dedicated mobile field to billing"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:112
+msgid "Use existing billing phone field"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:162
+msgid "Field Requirement"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:164
+msgid "Field requirement"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:165
+msgid "Select requirement"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:168
+msgid "Required — Users must enter a mobile number"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:169
+msgid "Optional — Users can skip this field"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:175
+msgid "Placeholder Text"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:178
+msgid "e.g., +1 555 000 0000"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:179
+msgid "Example format shown in the empty field."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:191
+#: resources/react/src/pages/PhoneConfig.jsx:199
+msgid "International Phone Input"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:194
+#: resources/react/src/pages/PhoneConfig.jsx:200
+msgid "Show a country flag selector for international phone number formatting."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:208
+msgid "Limit Countries"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:212
+msgid "All countries"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:214
+msgid "Only show these countries in the dropdown. Leave empty to show all."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:222
+msgid "None selected"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:224
+msgid "Show these countries at the top of the dropdown for quick access."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:232
+msgid "Default Country Code"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:237
+msgid "Select country code"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:242
+msgid "Automatically prepend this country code to new phone numbers. Changing this will not update numbers already stored in the database."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:246
+msgid "Please select a country code. This is required for proper phone number storage."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:253
+msgid "Minimum Digits"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:258
+msgid "Minimum number of digits required (excluding country code)."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:261
+msgid "Maximum Digits"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:266
+msgid "Maximum number of digits allowed (excluding country code)."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:279
+msgid "Phone Number Improvement"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:282
+msgid "Review and update your phone numbers to include the country code for better delivery reliability."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:291
+msgid "Open Update Wizard"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:301
+msgid "Data Protection"
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:304
+msgid "Privacy and GDPR compliance settings."
+msgstr ""
+
+#: resources/react/src/pages/PhoneConfig.jsx:310
+msgid "Enable data export/deletion by mobile number and add SMS consent checkbox to forms."
+msgstr ""
+
+#: resources/react/src/pages/Privacy.jsx:132
+msgid "WordPress User"
+msgstr ""
+
+#: resources/react/src/pages/Privacy.jsx:134
+msgid "Subscriber"
+msgstr ""
+
+#: resources/react/src/pages/Privacy.jsx:189
+msgid "GDPR Compliance Required"
+msgstr ""
+
+#: resources/react/src/pages/Privacy.jsx:192
+msgid "Enable the GDPR Compliance setting to access privacy data management tools."
+msgstr ""
+
+#: resources/react/src/pages/Privacy.jsx:195
+msgid "Go to Phone Settings"
+msgstr ""
+
+#: resources/react/src/pages/Privacy.jsx:314
+msgid "Export CSV"
+msgstr ""
+
+#: resources/react/src/pages/Privacy.jsx:315
+#, js-format
+msgid "Exported %d records successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:74
+#: resources/react/src/pages/Scheduled.jsx:107
+msgid "Scheduled message deleted successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:121
+msgid "Scheduled message updated successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:170
+msgid "Message sent successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:173
+#: resources/react/src/pages/SendSms.jsx:237
+#: resources/react/src/pages/Subscribers.jsx:327
+msgid "Failed to send message"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:259
+msgid "Failed to load scheduled messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:293
+msgid "No scheduled messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:296
+msgid "Schedule SMS messages to be sent at a specific date and time. They will appear here until they are sent."
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:370
+#, js-format
+msgid "Exported %d scheduled messages successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:392
+msgid "Search scheduled messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:480
+msgid "No scheduled messages match your filters"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:492
+msgid "Scheduled Message Details"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:495
+msgid "Scheduled for"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:590
+msgid "Delete Scheduled Message"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:591
+msgid "Are you sure you want to delete this scheduled message?"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:616
+msgid "Delete Scheduled Messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:617
+msgid "Are you sure you want to delete the selected scheduled messages?"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:632
+msgid "Edit Scheduled Message"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:647
+#: resources/react/src/pages/Scheduled.jsx:1265
+#: resources/react/src/pages/SendSms.jsx:463
+msgid "Site's time zone"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:707
+#: resources/react/src/pages/Scheduled.jsx:740
+msgid "Repeating message deleted successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:759
+msgid "Repeating message updated successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:869
+msgid "Failed to load repeating messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:901
+msgid "No repeating messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:904
+msgid "Create recurring SMS messages that are sent automatically at regular intervals. Perfect for reminders, notifications, and scheduled updates."
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:961
+#, js-format
+msgid "Exported %d repeating messages successfully"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:983
+msgid "Search repeating messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1062
+msgid "No repeating messages match your filters"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1074
+msgid "Repeating Message Details"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1171
+msgid "Delete Repeating Message"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1172
+msgid "Are you sure you want to delete this repeating message? This will stop all future occurrences."
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1197
+msgid "Delete Repeating Messages"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1198
+msgid "Are you sure you want to delete the selected repeating messages?"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1213
+msgid "Edit Repeating Message"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1252
+#: resources/react/src/pages/SendSms.jsx:541
+msgid "Repeat Forever"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1256
+msgid "End on"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1313
+msgid "WSMS Pro Required"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1316
+msgid "Schedule SMS messages for later delivery or create recurring messages with WSMS Pro. Perfect for reminders, notifications, and automated campaigns."
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1341
+msgid "Scheduled SMS"
+msgstr ""
+
+#: resources/react/src/pages/Scheduled.jsx:1345
+msgid "Repeating SMS"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:227
+#, js-format
+msgid "Message sent. %d recipient(s) skipped — their country codes don't match your country restriction settings."
+msgstr ""
+
+#. translators: %d: number of recipients
+#: resources/react/src/pages/SendSms.jsx:231
+#, js-format
+msgid "Message sent successfully to %d recipient(s)"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:248
+msgid "No SMS gateway configured."
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:248
+msgid "You need to set up a gateway before you can send messages."
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:253
+msgid "Configure Gateway"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:289
+msgid "Format:"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:303
+msgid "Compose Message"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:325
+msgid "Type your message here..."
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:344
+msgid "Flash"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:408
+msgid "This gateway doesn't support bulk SMS. Only the first number will receive the message."
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:422
+msgid "Scheduling Options"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:433
+#: resources/react/src/pages/SendSms.jsx:441
+msgid "Schedule Message"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:436
+msgid "Send this message at a specific date and time"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:452
+msgid "Schedule Date & Time"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:473
+#: resources/react/src/pages/SendSms.jsx:481
+msgid "Repeat Message"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:476
+msgid "Automatically send this message on a recurring schedule"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:493
+msgid "Repeat Every"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:505
+msgid "Repeat interval unit"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:509
+msgid "Day(s)"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:510
+msgid "Week(s)"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:511
+msgid "Month(s)"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:512
+msgid "Year(s)"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:521
+msgid "End Date"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:562
+msgid "Recipients:"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:570
+msgid "Segments:"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:576
+msgid "Total:"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:586
+msgid "Checking recipients..."
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:588
+msgid "Configure gateway first"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:590
+msgid "Add message and recipients"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:592
+msgid "Enter a message"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:594
+msgid "Add recipients"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:596
+msgid "Selected groups/roles have no subscribers"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:598
+msgid "Select schedule date and time"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:600
+msgid "Select repeat end date"
+msgstr ""
+
+#: resources/react/src/pages/SendSms.jsx:614
+msgid "Review & Send"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:62
+#: resources/react/src/pages/SmsCampaigns.jsx:283
+#: resources/react/src/pages/SmsCampaigns.jsx:840
+msgid "Draft"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:84
+msgid "Queued"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:85
+msgid "Processing"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:86
+msgid "Completed"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:108
+#: resources/react/src/pages/SmsCampaigns.jsx:391
+msgid "Right Away"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:111
+#: resources/react/src/pages/SmsCampaigns.jsx:392
+msgid "Specific Date"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:112
+#: resources/react/src/pages/SmsCampaigns.jsx:393
+msgid "After Placing Order"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:265
+msgid "Campaign Title"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:270
+msgid "Enter campaign title..."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:292
+#: resources/react/src/pages/SmsCampaigns.jsx:958
+msgid "Conditions"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:296
+msgid "No conditions added. Campaign will match all orders."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:305
+#: resources/react/src/pages/SmsCampaigns.jsx:965
+msgid "OR"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:311
+msgid "Send SMS to orders if"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:317
+#: resources/react/src/pages/SmsCampaigns.jsx:973
+msgid "AND"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:326
+msgid "Condition type"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:327
+msgid "Select type..."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:342
+msgid "Condition value"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:343
+msgid "Select value..."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:367
+msgid "Add condition"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:375
+msgid "Add condition group"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:381
+msgid "When to Send"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:386
+msgid "When to send"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:387
+msgid "Select when to send..."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:405
+msgid "Specific date"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:417
+msgid "Delay value"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:425
+msgid "Delay unit"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:435
+msgid "after order is placed"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:442
+msgid "Message Content"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:447
+msgid "Enter your SMS message..."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:478
+msgid "Update Campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:478
+#: resources/react/src/pages/SmsCampaigns.jsx:899
+msgid "Create Campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:492
+msgid "Campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:513
+#: resources/react/src/pages/SmsCampaigns.jsx:946
+msgid "Schedule"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:525
+msgid "Queue"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:536
+msgid "Created"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:554
+msgid "View Queue"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:587
+#: resources/react/src/pages/SmsCampaigns.jsx:612
+msgid "Campaign deleted successfully"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:627
+msgid "Order Status"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:628
+msgid "Coupon Code"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:629
+msgid "Product"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:630
+msgid "Product Type"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:669
+#: resources/react/src/pages/SmsCampaigns.jsx:683
+msgid "Failed to load campaign details"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:697
+msgid "Failed to load queue data"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:721
+msgid "Campaign updated successfully"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:724
+msgid "Campaign created successfully"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:729
+msgid "Failed to save campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:753
+msgid "Install and activate the WSMS WooCommerce Pro add-on to access SMS Campaigns."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:797
+msgid "Create targeted SMS marketing campaigns based on customer behavior. Set conditions, schedule delivery, and track results."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:803
+msgid "New Campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:823
+msgid "Search campaigns..."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:825
+msgid "Search campaigns"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:835
+#: resources/react/src/pages/SmsCampaigns.jsx:838
+msgid "All Statuses"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:888
+msgid "No campaigns found"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:899
+msgid "Edit Campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:903
+msgid "Update your SMS campaign settings."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:904
+msgid "Create a new targeted SMS marketing campaign."
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:930
+msgid "Campaign details and configuration"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:988
+msgid "Message Preview"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1002
+msgid "No message content"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1031
+msgid "Queue execution details and target orders"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1052
+msgid "Last Execution"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1068
+msgid "Target Orders"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1110
+msgid "Order ID"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1111
+msgid "Order Date"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1151
+msgid "No target orders found for this campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1171
+msgid "Delete Campaign"
+msgstr ""
+
+#: resources/react/src/pages/SmsCampaigns.jsx:1172
+msgid "Are you sure you want to delete this campaign? This action is irreversible and cannot be undone."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:102
+msgid "Subscribers updated successfully"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:119
+msgid "Phone number is required"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:243
+msgid "Subscriber added successfully"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:249
+msgid "Failed to add subscriber"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:276
+#, js-format
+msgid "Imported %d subscribers, skipped %d"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:283
+msgid "Import failed"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:309
+msgid "This recipient is outside your allowed countries. You can update this in Gateway > Country Restrictions."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:321
+#, js-format
+msgid "Message sent to %s"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:343
+#, js-format
+msgid "%d subscriber(s) moved to group"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:394
+msgid "Custom Fields"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:413
+msgid "more"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:435
+msgid "Activate Code"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:496
+#: resources/react/src/pages/Subscribers.jsx:1139
+msgid "Move to Group"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:501
+#: resources/react/src/pages/Subscribers.jsx:503
+msgid "Activate Selected"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:506
+#: resources/react/src/pages/Subscribers.jsx:508
+msgid "Deactivate Selected"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:532
+msgid "Failed to load subscribers"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:562
+msgid "No subscribers yet"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:565
+msgid "Start building your SMS audience. Add subscribers manually, import from CSV, or let users subscribe through your website forms."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:621
+msgid "Import from CSV"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:686
+msgid "Import"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:690
+#, js-format
+msgid "Exported %d subscribers successfully"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:708
+msgid "Search..."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:709
+msgid "Search subscribers"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:717
+msgid "Filter by group"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:746
+#: resources/react/src/pages/Subscribers.jsx:749
+msgid "All Countries"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:756
+msgid "Filter by country"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:781
+msgid "Refresh subscribers"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:796
+msgid "Quick Add"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:804
+msgid "Name (optional)"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:805
+msgid "Subscriber name"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1089
+msgid "No groups available"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1092
+msgid "Create a group first in the Groups page to organize your subscribers."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1098
+msgid "Select Group"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1101
+msgid "Choose a group..."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1114
+#, js-format
+msgid "This will move %d subscriber(s) to the selected group."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1136
+msgid "Moving..."
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1153
+msgid "Delete Subscriber"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1154
+msgid "Are you sure you want to delete this subscriber?"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1176
+msgid "Delete Subscribers"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1177
+msgid "Are you sure you want to delete the selected subscribers?"
+msgstr ""
+
+#: resources/react/src/pages/Subscribers.jsx:1181
+#, js-format
+msgid "%d subscriber(s) will be permanently deleted."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:75
+msgid "Failed to load commands"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:124
+msgid "Command name is required"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:125
+msgid "Please select an action"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:129
+msgid "Command created successfully"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:130
+msgid "Command updated successfully"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:138
+msgid "Command deleted"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:204
+msgid "Command enabled"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:204
+msgid "Command disabled"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:210
+msgid "Failed to toggle command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:279
+#: resources/react/src/pages/TwoWayCommands.jsx:403
+#: resources/react/src/pages/TwoWayCommands.jsx:412
+msgid "Action"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:289
+msgid "Response Preview"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:309
+msgid "Toggle"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:338
+#: resources/react/src/pages/TwoWayInbox.jsx:447
+#: resources/react/src/pages/TwoWaySettings.jsx:165
+msgid "Two-Way SMS Add-on Required"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:341
+msgid "Install and activate the WSMS Two-Way add-on to create auto-reply commands."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:373
+msgid "Edit Command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:373
+#: resources/react/src/pages/TwoWayCommands.jsx:683
+msgid "New Command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:377
+msgid "Update the auto-reply rule settings"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:378
+msgid "Create a new auto-reply rule for incoming messages"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:387
+msgid "Command Name"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:390
+msgid "e.g., HELP, INFO, STOP"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:398
+msgid "The keyword that triggers this command when received"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:413
+msgid "Select an action"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:418
+msgid "Loading actions..."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:422
+msgid "No actions available"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:447
+#: resources/react/src/pages/TwoWayCommands.jsx:454
+msgid "Option"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:455
+msgid "Select an option"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:469
+msgid "Success Response"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:472
+msgid "Message sent when the action succeeds"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:484
+#: resources/react/src/pages/TwoWayCommands.jsx:527
+msgid "Insert"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:497
+#: resources/react/src/pages/TwoWayCommands.jsx:540
+msgid "Click to insert"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:506
+msgid "Select an action to see available variables"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:512
+msgid "Failure Response"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:515
+msgid "Message sent when the action fails"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:553
+msgid "Enable or disable this command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:578
+msgid "Create Command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:590
+msgid "Delete Command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:591
+msgid "Are you sure you want to delete this command?"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:618
+msgid "No commands yet"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:621
+msgid "Create auto-reply rules that trigger actions when subscribers send specific keywords via SMS."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:625
+msgid "Create First Command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:700
+msgid "Search commands..."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:702
+msgid "Search commands"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:720
+msgid "Filter by action"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:721
+#: resources/react/src/pages/TwoWayCommands.jsx:724
+#: resources/react/src/pages/TwoWayInbox.jsx:571
+#: resources/react/src/pages/TwoWayInbox.jsx:574
+msgid "All Actions"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:752
+msgid "Refresh commands"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayCommands.jsx:772
+msgid "No commands match your filters"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:133
+#: resources/react/src/pages/TwoWayInbox.jsx:144
+msgid "Message deleted"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:134
+msgid "Messages deleted"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:202
+msgid "Failed to load conversation"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:222
+msgid "Just now"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:228
+msgid "Reply sent"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:280
+msgid "Failed to export messages"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:285
+#: resources/react/src/pages/TwoWayInbox.jsx:423
+#: resources/react/src/pages/TwoWayInbox.jsx:426
+msgid "Mark as Read"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:291
+msgid "Messages marked as read"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:293
+msgid "Failed to mark messages as read"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:334
+msgid "Contact"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:357
+#: resources/react/src/pages/TwoWayInbox.jsx:702
+msgid "Command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:365
+msgid "Action Status"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:385
+#: resources/react/src/pages/TwoWayInbox.jsx:387
+#: resources/react/src/pages/TwoWayInbox.jsx:602
+msgid "Read"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:388
+msgid "New"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:395
+msgid "View"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:403
+#: resources/react/src/pages/TwoWayInbox.jsx:794
+msgid "Conversation"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:450
+msgid "Install and activate the WSMS Two-Way add-on to receive incoming messages."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:513
+msgid "This Week"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:535
+#: resources/react/src/pages/TwoWayInbox.jsx:601
+msgid "Unread"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:570
+msgid "Filter by action status"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:582
+msgid "Filter by command"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:583
+#: resources/react/src/pages/TwoWayInbox.jsx:586
+msgid "All Commands"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:596
+msgid "Filter by read status"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:674
+msgid "Received"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:742
+msgid "Send an SMS reply to this number"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:754
+msgid "Original message"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:761
+msgid "Type your reply..."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:811
+msgid "No messages in this conversation"
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:859
+msgid "Type a reply..."
+msgstr ""
+
+#: resources/react/src/pages/TwoWayInbox.jsx:860
+msgid "Reply message"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:52
+#: resources/react/src/pages/TwoWaySettings.jsx:421
+#, js-format
+msgid "New SMS from %sender_number%: %sms_content%"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:68
+msgid "Copied"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:69
+msgid "Webhook URL copied to clipboard"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:76
+msgid "Failed to copy URL"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:95
+#: resources/react/src/pages/TwoWaySettings.jsx:130
+msgid "Success"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:96
+msgid "Webhook token has been reset. Refreshing..."
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:101
+msgid "Failed to reset token"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:106
+msgid "Failed to reset webhook token"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:131
+msgid "Webhook registered successfully with your gateway."
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:135
+#: resources/react/src/pages/TwoWaySettings.jsx:140
+msgid "Failed to register webhook"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:156
+msgid "Two-Way SMS Settings"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:159
+msgid "Configure your two-way SMS settings and webhook"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:167
+msgid "Install and activate the WSMS Two-Way add-on to configure these settings."
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:197
+msgid "Gateway Connection"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:200
+msgid "Webhook configuration for receiving incoming SMS messages"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:206
+#, js-format
+msgid "Webhook setup for %s"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:207
+msgid "Gateway webhook setup guide"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:209
+msgid "Two-Way SMS documentation"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:233
+msgid "Connected Gateway"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:252
+msgid "This gateway does not support incoming messages"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:257
+msgid "Configure a gateway in Gateway settings first"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:268
+#: resources/react/src/pages/TwoWaySettings.jsx:280
+msgid "Webhook URL"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:271
+msgid "Automatic registration"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:271
+msgid "Manual setup required"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:288
+#: resources/react/src/pages/TwoWaySettings.jsx:377
+msgid "Copy URL"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:302
+msgid "Reset Token"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:325
+msgid "Registering..."
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:330
+msgid "Register Webhook"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:342
+msgid "Copy this URL and add it to your gateway's webhook settings."
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:350
+msgid "Open Gateway Panel"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:361
+msgid "Alternative URL (token in the path)"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:364
+msgid "Some gateways remove everything after the \"?\" when they save a webhook URL, which makes incoming messages fail. Use this URL instead if that happens."
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:370
+msgid "Alternative webhook URL"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:398
+msgid "Admin Notifications"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:401
+msgid "Choose how you want to be notified when new SMS messages arrive"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:406
+msgid "Forward to SMS"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:407
+msgid "Send a copy of incoming messages to your admin mobile number"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:427
+msgid "Forward to Email"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:428
+msgid "Send incoming messages to your WordPress admin email"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:443
+msgid "Control how incoming messages are stored in your database"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:448
+msgid "Save Messages to Inbox"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:449
+msgid "Store incoming SMS messages for viewing and replying later"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:455
+msgid "Auto-Delete After"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:458
+msgid "Select period"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:459
+msgid "Automatically remove old messages to save database space"
+msgstr ""
+
+#: resources/react/src/pages/TwoWaySettings.jsx:464
+msgid "1 year"
+msgstr ""
+
+#: resources/blocks/send-sms/block.json
+msgctxt "block title"
+msgid "Send SMS"
+msgstr ""
+
+#: resources/blocks/subscribe/block.json
+msgctxt "block title"
+msgid "Subscribe"
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -155,7 +155,7 @@ All premium features + all add-ons in one package.
 14. SMS Stats Dashboard Widget
 
 == Changelog ==
-= v7.2.6 - 2026-06-** =
+= v7.2.6 - 2026-07-30 =
 - **New:** Added the LogisticSMS gateway (Iran).
 - **New:** Added the `wpsms_unsubscribe_success_message` filter to customize the newsletter unsubscribe confirmation message, with the unsubscribed group passed to the filter for both the unsubscribe form and the unsubscribe link.
 - **Enhancement:** General security hardening across admin endpoints, subscriber and newsletter handling, gateway connections, and data exports.


### PR DESCRIPTION
## Summary
- set the WSMS 7.2.6 release date to July 30, 2026 in `CHANGELOG.md`
- set the same date in the WordPress.org changelog section of `readme.txt`
- regenerate `languages/wp-sms.pot` with `wp i18n make-pot . languages/wp-sms.pot`

## Verification
- both changelog headings use `2026-07-30`
- POT metadata reports WSMS 7.2.6, the `wp-sms` text domain, and the correct WordPress.org plugin support URL
- WP-CLI completed with `POT file successfully generated`
- no runtime code changed
