### PR TITLE
Reject invalid characters in manual phone numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 # WSMS - WordPress SMS Plugin
 
+> 🚀 **WSMS v8 Early Access is open** — a major rewrite, and we'd love your feedback. Developers and active users welcome. **[Want in? Comment here →](https://github.com/wp-sms/wp-sms/discussions/482)**
+
 SMS & MMS Notifications, 2FA, OTP, and Integrations with E-Commerce and Form Builders. Send messages through **200+ gateways** including Twilio, Plivo, Clickatell, BulkSMS, Infobip, Vonage (Nexmo), Messagebird, ClickSend and more. [See all gateways](https://wsms.io/gateways/)
 
 <p align="center">

--- a/resources/react/src/components/shared/RecipientSelector.jsx
+++ b/resources/react/src/components/shared/RecipientSelector.jsx
@@ -14,6 +14,8 @@ const TABS = [
   { id: 'numbers', label: __('Numbers', 'wp-sms'), icon: Phone, description: __('Manual entry', 'wp-sms') },
 ]
 
+const PHONE_NUMBER_PATTERN = /^\+?\d(?:[\d ]*\d)?$/
+
 // Map icon names from PHP to lucide-react components
 const ICON_MAP = {
   ShoppingCart,
@@ -122,7 +124,7 @@ const RecipientSelector = React.forwardRef(
       const numbers = trimmed
         .split(/[,\n]/)
         .map((n) => n.trim())
-        .filter((n) => n && !value.numbers.includes(n))
+        .filter((n) => PHONE_NUMBER_PATTERN.test(n) && !value.numbers.includes(n))
 
       if (numbers.length > 0) {
         onChange?.({ ...value, numbers: [...value.numbers, ...numbers] })

--- a/resources/react/src/components/shared/RecipientSelector.jsx
+++ b/resources/react/src/components/shared/RecipientSelector.jsx
@@ -572,9 +572,10 @@ const RecipientSelector = React.forwardRef(
                 {/* Input Area */}
                 <div className="wsms-flex wsms-gap-2">
                   <Input
-                    type="text"
+                    type="tel"
+                    inputMode="tel"
                     value={numberInput}
-                    onChange={(e) => setNumberInput(e.target.value)}
+                    onChange={(e) => setNumberInput(e.target.value.replace(/[^0-9+,\s]/g, ''))}
                     onKeyDown={handleKeyDown}
                     placeholder={__('Enter phone number...', 'wp-sms')}
                     aria-label={__('Phone number', 'wp-sms')}

--- a/tests/js/RecipientSelector.test.jsx
+++ b/tests/js/RecipientSelector.test.jsx
@@ -28,4 +28,21 @@ describe('RecipientSelector', () => {
       numbers: ['+1 234', '567890'],
     })
   })
+
+  test('does not add malformed sanitized phone numbers', () => {
+    const handleChange = jest.fn()
+
+    render(<RecipientSelector value={emptyRecipients} onChange={handleChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /numbers/i }))
+
+    fireEvent.change(screen.getByRole('textbox', { name: /phone number/i }), {
+      target: { value: '+++, 1++2, + 123, +123, 456 789' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /add number/i }))
+
+    expect(handleChange).toHaveBeenCalledWith({
+      ...emptyRecipients,
+      numbers: ['+123', '456 789'],
+    })
+  })
 })

--- a/tests/js/RecipientSelector.test.jsx
+++ b/tests/js/RecipientSelector.test.jsx
@@ -19,7 +19,7 @@ describe('RecipientSelector', () => {
     const input = screen.getByRole('textbox', { name: /phone number/i })
     fireEvent.change(input, { target: { value: 'abc+1 234, test\n567-890' } })
 
-    expect(input).toHaveValue('+1 234, \n567890')
+    expect(input).toHaveValue('+1 234, 567890')
 
     fireEvent.click(screen.getByRole('button', { name: /add number/i }))
 

--- a/tests/js/RecipientSelector.test.jsx
+++ b/tests/js/RecipientSelector.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { RecipientSelector } from '@/components/shared/RecipientSelector'
+
+const emptyRecipients = {
+  groups: [],
+  roles: [],
+  users: [],
+  numbers: [],
+}
+
+describe('RecipientSelector', () => {
+  test('rejects unsupported characters from manual phone numbers', () => {
+    const handleChange = jest.fn()
+
+    render(<RecipientSelector value={emptyRecipients} onChange={handleChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /numbers/i }))
+
+    const input = screen.getByRole('textbox', { name: /phone number/i })
+    fireEvent.change(input, { target: { value: 'abc+1 234, test\n567-890' } })
+
+    expect(input).toHaveValue('+1 234, \n567890')
+
+    fireEvent.click(screen.getByRole('button', { name: /add number/i }))
+
+    expect(handleChange).toHaveBeenCalledWith({
+      ...emptyRecipients,
+      numbers: ['+1 234', '567890'],
+    })
+  })
+})


### PR DESCRIPTION
## What changed
- switched the manual recipient field to a telephone input with a mobile-friendly keypad
- strips unsupported characters while preserving digits, an optional leading `+`, spaces, and comma-separated bulk entry
- validates each sanitized token before it enters the recipient payload
- added focused regression coverage for unsupported characters and malformed tokens

## Why
The Numbers tab previously accepted arbitrary text and could pass invalid recipient values into the send flow.

## How to test
1. Open **WSMS → Send SMS → Recipients → Numbers**.
2. Enter `abc+1 234, test567-890`.
3. Confirm the field shows `+1 234, 567890` and adds `+1 234` and `567890`.
4. Enter `+++, 1++2, + 123, +123, 456 789`.
5. Confirm only `+123` and `456 789` are added.

## Automated test
- `pnpm test -- --runInBand tests/js/RecipientSelector.test.jsx` — 2 tests passed

Closes #505
