### PR TITLE
Fail gracefully when plugin files are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v7.2.7 - Unreleased
+- **Fix:** An update that does not finish no longer takes the whole site down. When plugin files are missing, WP SMS now stops on its own and shows a notice explaining that reinstalling the plugin restores them; your settings and data are not affected (ticket #17381).
+
 v7.2.6 - 2026-07-30
 - **New:** Added the LogisticSMS gateway
 - **New:** Added the `wpsms_unsubscribe_success_message` filter to customize the newsletter unsubscribe confirmation message, with the unsubscribed group passed to the filter for both the unsubscribe form and the unsubscribe link.

--- a/includes/class-wpsms.php
+++ b/includes/class-wpsms.php
@@ -97,22 +97,54 @@ class WP_SMS
 
     /**
      * Constructors plugin Setup
+     *
+     * The bootstrap is wrapped because a partial or interrupted update can leave
+     * the autoloader in place while individual class files are missing. Without
+     * the guard the first unresolved class raises a fatal error during
+     * plugins_loaded, which takes the entire site down instead of just this
+     * plugin. Degrade to an admin notice and let the rest of the site load.
      */
     public function plugin_setup()
     {
         $this->loadTextDomain();
 
-        add_action('init', array($this, 'init'));
+        try {
+            add_action('init', array($this, 'init'));
 
-        $this->includes();
+            $this->includes();
 
-        // Initialize default settings if not already present
-        if (!get_option('wpsms_settings')) {
-            require_once WP_SMS_DIR . 'includes/admin/settings/class-wpsms-settings.php';
-            update_option('wpsms_settings', \WP_SMS\Settings::getDefaultSettings());
+            // Initialize default settings if not already present
+            if (!get_option('wpsms_settings')) {
+                require_once WP_SMS_DIR . 'includes/admin/settings/class-wpsms-settings.php';
+                update_option('wpsms_settings', \WP_SMS\Settings::getDefaultSettings());
+            }
+
+            $this->setupBackgroundProcess();
+        } catch (\Throwable $error) {
+            $this->handleBootstrapFailure($error);
         }
+    }
 
-        $this->setupBackgroundProcess();
+    /**
+     * Reports a bootstrap failure without terminating the request.
+     *
+     * @param \Throwable $error The error raised while loading the plugin.
+     * @return void
+     */
+    private function handleBootstrapFailure($error)
+    {
+        error_log(sprintf('WP SMS could not finish loading: %s', $error->getMessage()));
+
+        add_action('admin_notices', function () {
+            if (!current_user_can('activate_plugins')) {
+                return;
+            }
+
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html__('WP SMS could not finish loading because some of its files are missing or unreadable. This usually means an update did not finish. Reinstalling the plugin restores the missing files; your settings and data are not affected.', 'wp-sms')
+            );
+        });
     }
 
     /**

--- a/includes/class-wpsms.php
+++ b/includes/class-wpsms.php
@@ -109,8 +109,6 @@ class WP_SMS
         $this->loadTextDomain();
 
         try {
-            add_action('init', array($this, 'init'));
-
             $this->includes();
 
             // Initialize default settings if not already present
@@ -120,6 +118,11 @@ class WP_SMS
             }
 
             $this->setupBackgroundProcess();
+
+            // Registered last so a failed bootstrap never leaves the init callback
+            // behind, which would run the gateway setup against a plugin whose
+            // managers were never constructed.
+            add_action('init', array($this, 'init'));
         } catch (\Throwable $error) {
             $this->handleBootstrapFailure($error);
         }
@@ -133,7 +136,13 @@ class WP_SMS
      */
     private function handleBootstrapFailure($error)
     {
-        error_log(sprintf('WP SMS could not finish loading: %s', $error->getMessage()));
+        // plugin_setup() runs on every request, so logging unconditionally would
+        // fill the error log and bury the first occurrence, which is the one that
+        // identifies the cause. Record it at most once an hour.
+        if (!get_transient('wp_sms_bootstrap_failure_logged')) {
+            error_log(sprintf('WP SMS could not finish loading: %s', $error->getMessage()));
+            set_transient('wp_sms_bootstrap_failure_logged', 1, HOUR_IN_SECONDS);
+        }
 
         add_action('admin_notices', function () {
             if (!current_user_can('activate_plugins')) {
@@ -347,6 +356,13 @@ class WP_SMS
      */
     public function getRemoteRequestAsync()
     {
+        // Stays null when the bootstrap aborted before setupBackgroundProcess().
+        // Callers chain straight onto the result, so build it on demand rather
+        // than handing back null and turning a contained failure into a fatal.
+        if ($this->remoteRequestAsync === null) {
+            $this->remoteRequestAsync = new RemoteRequestAsync();
+        }
+
         return $this->remoteRequestAsync;
     }
 
@@ -355,6 +371,12 @@ class WP_SMS
      */
     public function getRemoteRequestQueue()
     {
+        // See getRemoteRequestAsync(): built on demand so a failed bootstrap does
+        // not leave callers dereferencing null.
+        if ($this->remoteRequestQueue === null) {
+            $this->remoteRequestQueue = new RemoteRequestQueue();
+        }
+
         return $this->remoteRequestQueue;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,9 @@ All premium features + all add-ons in one package.
 14. SMS Stats Dashboard Widget
 
 == Changelog ==
+= v7.2.7 - Unreleased =
+- **Fix:** An update that does not finish no longer takes the whole site down. When plugin files are missing, WP SMS now stops on its own and shows a notice explaining that reinstalling the plugin restores them; your settings and data are not affected (ticket #17381).
+
 = v7.2.6 - 2026-07-30 =
 - **New:** Added the LogisticSMS gateway
 - **New:** Added the `wpsms_unsubscribe_success_message` filter to customize the newsletter unsubscribe confirmation message, with the unsubscribed group passed to the filter for both the unsubscribe form and the unsubscribe link.

--- a/wp-sms.php
+++ b/wp-sms.php
@@ -21,10 +21,26 @@ if (!defined('ABSPATH')) {
 
 /**
  * Load Autoloader (handles both WP_SMS\ classes and prefixed dependencies)
+ *
+ * A partial or interrupted update can leave the plugin directory without the
+ * generated autoloader. Returning silently makes the plugin look active while
+ * loading nothing, which then surfaces as an unrelated fatal error in add-ons
+ * that expect our classes. Tell the administrator what actually happened.
  */
 if (file_exists(__DIR__ . '/packages/autoload.php')) {
     require_once __DIR__ . '/packages/autoload.php';
 } else {
+    add_action('admin_notices', function () {
+        if (!current_user_can('activate_plugins')) {
+            return;
+        }
+
+        printf(
+            '<div class="notice notice-error"><p>%s</p></div>',
+            esc_html__('WP SMS could not start because some of its files are missing. This usually means an update did not finish. Reinstalling the plugin restores the missing files; your settings and data are not affected.', 'wp-sms')
+        );
+    });
+
     return;
 }
 


### PR DESCRIPTION
## Problem

A site running 7.2.6 went down with a critical error after an automatic update (helpdesk #17381). The log showed:

```
PHP Fatal error: Uncaught Error: Class "WP_SMS\Components\Assets" not found
in /wp-content/plugins/wp-sms/includes/class-wpsms.php on line 189
```

The released 7.2.6 package is not at fault. I downloaded the ZIP from wordpress.org and compared it to 7.2.5: no PHP files were removed, `packages/autoload.php` is present and byte-identical, and every PHP file passes a syntax check. `class-wpsms.php` itself did not change between the two releases. The site simply ended up with an incomplete plugin directory, which is what an interrupted update leaves behind.

What this PR fixes is the reaction to that state. Today a partial install takes the entire site down instead of just disabling this plugin, and the error it produces points away from the real cause.

There are two separate paths:

**1. `wp-sms.php` returned silently when the autoloader was missing**

```php
if (file_exists(__DIR__ . '/packages/autoload.php')) {
    require_once __DIR__ . '/packages/autoload.php';
} else {
    return;   // plugin looks active, loads nothing, says nothing
}
```

The plugin still shows as active while defining none of its classes. Add-ons then fail with `Class "WP_SMS\Option" not found`, which looks like an add-on bug.

**2. `plugin_setup()` called into autoloaded classes unguarded**

`includes()` calls `Assets::init()` and then instantiates a dozen managers. With the autoloader present but one class file missing under `src/`, the first unresolved class raises a fatal error during `plugins_loaded` and the whole site returns a critical error.

## Change

Both paths now log the failure and show the administrator an admin notice saying files are missing and that reinstalling restores them. The plugin stops loading; the rest of the site does not.

The notice is only shown to users who can activate plugins.

## Verification

Against WordPress 7.0.2 and PHP 8.2 (the reporter's versions), using a pristine 7.2.6 install from wordpress.org:

| Scenario | Before | After |
|---|---|---|
| Healthy install | loads | loads, no notice, no behaviour change |
| `src/Components/Assets.php` removed | critical error at `class-wpsms.php:189` | site loads, notice shown |
| `packages/autoload.php` removed | plugin silently does nothing | site loads, notice shown |

## Scope

This covers failures originating in this plugin. It does not fully stop a broken install from breaking dependent add-ons: they consume WP SMS classes from their own hooks and each carries its own dependency check. The matching Pro change is in wp-sms-pro, and the remaining add-ons are follow-up work.

Refs helpdesk #17381.
