### PR TITLE
Forminator: record why spam and abandoned submissions are skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v7.2.7 - Unreleased
 - **Fix:** An update that does not finish no longer takes the whole site down. When plugin files are missing, WP SMS now stops on its own and shows a notice explaining that reinstalling the plugin restores them; your settings and data are not affected (ticket #17381).
+- **Enhancement:** When Forminator treats a submission as spam or abandoned, WP SMS now records why no SMS was sent. Previously the message was skipped silently, which looked the same as a broken integration (issue [#509](https://github.com/wp-sms/wp-sms/issues/509)).
 
 v7.2.6 - 2026-07-30
 - **New:** Added the LogisticSMS gateway

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,7 @@ All premium features + all add-ons in one package.
 == Changelog ==
 = v7.2.7 - Unreleased =
 - **Fix:** An update that does not finish no longer takes the whole site down. When plugin files are missing, WP SMS now stops on its own and shows a notice explaining that reinstalling the plugin restores them; your settings and data are not affected (ticket #17381).
+- **Enhancement:** When Forminator treats a submission as spam or abandoned, WP SMS now records why no SMS was sent. Previously the message was skipped silently, which looked the same as a broken integration (issue [#509](https://github.com/wp-sms/wp-sms/issues/509)).
 
 = v7.2.6 - 2026-07-30 =
 - **New:** Added the LogisticSMS gateway

--- a/src/Services/Forminator/Forminator.php
+++ b/src/Services/Forminator/Forminator.php
@@ -17,6 +17,42 @@ class Forminator
     {
         add_action("forminator_form_draft_after_save_entry", array($this, 'handle_sms'), 10, 2);
         add_action("forminator_form_after_save_entry", array($this, 'handle_sms'), 10, 2);
+
+        // Forminator builds the hook name from the submission status, so a submission
+        // it treats as spam or abandoned fires a different event and never reaches
+        // handle_sms(). Not sending those is intentional, but the skip is otherwise
+        // invisible: the entry is saved and the email notification still goes out
+        // while the Outbox stays empty, which looks exactly like a broken integration.
+        add_action("forminator_form_spam_after_save_entry", array($this, 'log_skipped_sms'), 10, 2);
+        add_action("forminator_form_abandoned_after_save_entry", array($this, 'log_skipped_sms'), 10, 2);
+    }
+
+    /**
+     * Records that a submission was skipped because Forminator flagged it, and why.
+     *
+     * @param int $form Form ID.
+     * @param array $res Forminator response.
+     * @return void
+     */
+    public function log_skipped_sms($form, $res)
+    {
+        $sms_options = Option::getOptions();
+
+        // Only report forms that were actually set up to send. Without this, spam on
+        // any unrelated form would fill the log with lines the site owner cannot act on.
+        $isConfigured = !empty($sms_options['forminator_notify_enable_form_' . $form])
+            || !empty($sms_options['forminator_notify_enable_field_form_' . $form]);
+
+        if (!$isConfigured) {
+            return;
+        }
+
+        $status = strpos((string)current_action(), '_spam_') !== false ? 'spam' : 'abandoned';
+
+        Logger::log(
+            sprintf('Forminator submission for form %d was flagged as %s by Forminator, so no SMS was sent.', $form, $status),
+            'warning'
+        );
     }
 
     public function handle_sms($form, $res)


### PR DESCRIPTION
Closes #509.

## Problem

Forminator builds its hook name from the submission status. From `save_entry()` in `library/abstracts/abstract-class-front-action.php`:

```php
$status_suffix = '';
if ( self::$is_spam )           { $status_suffix = '_spam'; }
elseif ( self::$is_abandoned )  { $status_suffix = '_abandoned'; }
elseif ( self::$is_draft )      { $status_suffix = '_draft'; }
...
do_action( 'forminator_' . static::$module_slug . $status_suffix . '_after_save_entry', self::$module_id, $response );
```

We only listened to the normal and draft variants, so a submission Forminator treated as spam or abandoned never reached `handle_sms()`.

Skipping those is intentional. The problem is that the skip left no trace. The entry is saved, the site owner's email notification still goes out, and the Outbox stays empty, which is indistinguishable from a broken integration. Support has nothing to point at, and a false-positive spam flag looks exactly like our bug.

## Change

Listen to both variants and log the reason instead of sending. Only forms actually configured to send are reported, so spam on unrelated forms does not fill the log with lines the site owner cannot act on.

This mirrors the warning added in 7.2.6 for a missing receiver field, so the two silent-failure paths in this integration now both leave a trace.

## Verification

Forminator 1.56.0 on WordPress 7.0.2 / PHP 8.2, driving the real hooks:

| Case | Result |
|---|---|
| Spam on a configured form | one warning naming form and status `spam` |
| Abandoned on a configured form | one warning naming form and status `abandoned` |
| Spam on an unconfigured form | nothing logged |
| Normal submission | unchanged, no skip line |

## Note, not addressed here

While testing I hit pre-existing PHP warnings in `Forminator::formFields()`:

```php
foreach ($form_fields as $field) {
    $fields[$field->slug] = $field->raw['field_label'];
}
```

`Forminator_API::get_form_fields()` does not always return objects. For a form ID that no longer exists it returns something else, and this loop then emits `Attempt to read property "raw" on array` on every submission. This runs on each Forminator submit via `NotificationFactory::getForminator()`, so a deleted or renamed form leaves warnings in the log. Out of scope for this PR, but worth a follow-up.

## Open product question

`abandoned` means someone entered a phone number and did not finish. That is arguably exactly who a follow-up SMS is for. This PR only makes the skip visible and deliberately does not change the behaviour. Worth deciding separately whether abandoned submissions should send.
