### PR TITLE
Add TSKIN WhatsApp gateway integration

### DIFF
--- a/includes/gateways/class-wpsms-gateway-tskin.php
+++ b/includes/gateways/class-wpsms-gateway-tskin.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace WP_SMS\Gateway;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class tskin extends \WP_SMS\Gateway
+{
+    private $apiEndpoint = 'https://app.tskin.sa/api/v1/send-message.php';
+
+    public $tariff = 'https://tskin.sa/';
+    public $unitrial = false;
+    public $unit;
+    public $flash = 'disabled';
+    public $isflash = false;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->bulk_send      = false;
+        $this->has_key        = true;
+        $this->validateNumber = __('Enter the recipient number with its country code and no leading plus sign, for example 966500000000.', 'wp-sms');
+        $this->documentUrl    = 'https://app.tskin.sa/wpplugin/assets/api-docs.php';
+        $this->gatewayFields  = [
+            'has_key' => [
+                'id'   => 'gateway_key',
+                'name' => __('API Key', 'wp-sms'),
+                'type' => 'password',
+                'desc' => __('Enter the API key from your TSKIN dashboard. The key is sent only in the secure Authorization header.', 'wp-sms'),
+            ],
+        ];
+    }
+
+    public function SendSMS()
+    {
+        $this->from = apply_filters('wp_sms_from', $this->from);
+        $this->to   = apply_filters('wp_sms_to', $this->to);
+        $this->msg  = apply_filters('wp_sms_msg', $this->msg);
+
+        $params = [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $this->has_key,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode([
+                'phone'        => $this->to[0],
+                'message_type' => 'text',
+                'message'      => $this->msg,
+            ]),
+        ];
+
+        try {
+            $response = $this->request('POST', $this->apiEndpoint, [], $params);
+
+            $this->log($this->from, $this->msg, $this->to, $response);
+            do_action('wp_sms_send', $response);
+
+            return $response;
+        } catch (\Exception $e) {
+            $this->log($this->from, $this->msg, $this->to, $e->getMessage(), 'error');
+
+            return new \WP_Error('send-sms', $e->getMessage());
+        }
+    }
+
+    public function GetCredit()
+    {
+        if (empty($this->has_key)) {
+            return new \WP_Error('account-credit', __('TSKIN API Key is required.', 'wp-sms'));
+        }
+
+        return true;
+    }
+}

--- a/tests/unit/gateways/TskinGatewayTest.php
+++ b/tests/unit/gateways/TskinGatewayTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace unit\gateways;
+
+use WP_Error;
+use WP_SMS\Gateway\tskin;
+use WP_UnitTestCase;
+
+$gatewayFile = dirname(__DIR__, 3) . '/includes/gateways/class-wpsms-gateway-tskin.php';
+if (file_exists($gatewayFile)) {
+    require_once $gatewayFile;
+}
+
+class TskinGatewayTest extends WP_UnitTestCase
+{
+    public function test_exposes_api_key_as_a_secret_setting()
+    {
+        $this->assertTrue(class_exists(tskin::class), 'The TSKIN gateway class should exist.');
+
+        $gateway = new tskin();
+
+        $this->assertSame('https://tskin.sa/', $gateway->tariff);
+        $this->assertSame('gateway_key', $gateway->gatewayFields['has_key']['id']);
+        $this->assertSame('password', $gateway->gatewayFields['has_key']['type']);
+    }
+
+    public function test_sends_text_message_with_bearer_authentication()
+    {
+        $this->assertTrue(method_exists(tskin::class, 'SendSMS'), 'The TSKIN gateway should send messages.');
+
+        $gateway = $this->getMockBuilder(tskin::class)
+            ->onlyMethods(array('request', 'log'))
+            ->getMock();
+
+        remove_all_filters('wp_sms_from');
+        remove_all_filters('wp_sms_to');
+        remove_all_filters('wp_sms_msg');
+
+        $gateway->has_key = 'test-api-key';
+        $gateway->to      = array('966500000000');
+        $gateway->msg     = 'Order shipped';
+
+        $response = (object) array(
+            'status'     => 'success',
+            'message_id' => 'wamid.test',
+            'recipient'  => '966500000000',
+            'type'       => 'text',
+        );
+
+        $gateway->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'https://app.tskin.sa/api/v1/send-message.php',
+                array(),
+                $this->callback(function ($params) {
+                    $this->assertSame('Bearer test-api-key', $params['headers']['Authorization']);
+                    $this->assertSame('application/json', $params['headers']['Content-Type']);
+                    $this->assertSame(
+                        array(
+                            'phone'        => '966500000000',
+                            'message_type' => 'text',
+                            'message'      => 'Order shipped',
+                        ),
+                        json_decode($params['body'], true)
+                    );
+
+                    return true;
+                })
+            )
+            ->willReturn($response);
+
+        $gateway->expects($this->once())
+            ->method('log')
+            ->with('', 'Order shipped', array('966500000000'), $response);
+
+        $this->assertSame($response, $gateway->SendSMS());
+    }
+
+    public function test_returns_useful_error_when_api_request_fails()
+    {
+        $gateway = $this->getMockBuilder(tskin::class)
+            ->onlyMethods(array('request', 'log'))
+            ->getMock();
+
+        remove_all_filters('wp_sms_from');
+        remove_all_filters('wp_sms_to');
+        remove_all_filters('wp_sms_msg');
+
+        $gateway->has_key = 'invalid-api-key';
+        $gateway->to      = array('966500000000');
+        $gateway->msg     = 'Order shipped';
+
+        $gateway->expects($this->once())
+            ->method('request')
+            ->willThrowException(new \Exception('Failed to get success response, Invalid API key'));
+
+        $gateway->expects($this->once())
+            ->method('log')
+            ->with(
+                '',
+                'Order shipped',
+                array('966500000000'),
+                'Failed to get success response, Invalid API key',
+                'error'
+            );
+
+        try {
+            $result = $gateway->SendSMS();
+        } catch (\Exception $exception) {
+            $this->fail('The gateway should convert API failures into WP_Error responses.');
+        }
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('send-sms', $result->get_error_code());
+        $this->assertSame('Failed to get success response, Invalid API key', $result->get_error_message());
+    }
+
+    public function test_gateway_status_requires_an_api_key()
+    {
+        $this->assertTrue(method_exists(tskin::class, 'GetCredit'), 'The TSKIN gateway should expose its configuration status.');
+
+        $gateway          = new tskin();
+        $gateway->has_key = '';
+        $result           = $gateway->GetCredit();
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('account-credit', $result->get_error_code());
+        $this->assertSame('TSKIN API Key is required.', $result->get_error_message());
+
+        $gateway->has_key = 'test-api-key';
+        $this->assertTrue($gateway->GetCredit());
+    }
+}


### PR DESCRIPTION
## What changed
- added a TSKIN WhatsApp gateway using the documented `send-message.php` endpoint
- added a password-masked API key setting and TSKIN setup documentation link
- sends basic text/session messages with Bearer authentication
- converts provider and transport failures into admin-facing `WP_Error` messages
- added focused gateway tests for settings, request payload/authentication, errors, and configuration status

## Why
This lets WP SMS users send WhatsApp notifications through TSKIN while keeping the API credential out of URLs, payloads, logs, and test fixtures. Provider catalog metadata remains separate for the gateway registry.

## How to test
```bash
WP_TESTS_PHPUNIT_POLYFILLS_PATH=/tmp/wp-test-deps/vendor/yoast/phpunit-polyfills php /tmp/phpunit.phar --configuration phpunit.xml.dist tests/unit/gateways/TskinGatewayTest.php
```

Result: 4 tests, 19 assertions passed. The public API endpoint and documented unauthenticated 401 error path were also verified without sending credentials or a message.

Closes #517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending SMS through the TSKIN gateway.
  * Supports API-key authentication, message delivery, delivery logging, and credit checks.
  * Provides clear error handling when requests fail or required credentials are missing.

* **Tests**
  * Added coverage for authentication, message requests, successful delivery logging, failures, and credit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->