### PR TITLE
Hide empty chatbox footer messages

### DIFF
--- a/resources/react/src/pages/MessageButton.jsx
+++ b/resources/react/src/pages/MessageButton.jsx
@@ -284,9 +284,7 @@ export default function MessageButton() {
     // Update footer text
     const footerTextEl = chatbox.querySelector('.wpsms-chatbox__info--text')
     if (footerTextEl) {
-      // Preserve any existing link
-      const existingLink = footerTextEl.querySelector('a')
-      footerTextEl.textContent = footerText || __('Chat with us on WhatsApp for instant support!', 'wp-sms')
+      footerTextEl.textContent = footerText
 
       // Add footer link if present
       if (footerLinkUrl && footerLinkTitle) {

--- a/src/Services/MessageButton/ChatBoxDecorator.php
+++ b/src/Services/MessageButton/ChatBoxDecorator.php
@@ -37,7 +37,9 @@ class ChatBoxDecorator
 
     public function getFooterText()
     {
-        return $this->getData('chatbox_footer_text');
+        $value = Option::getOption('chatbox_footer_text');
+
+        return $value === '' || $value === false || $value === null ? false : $value;
     }
 
     public function getFooterLinkUrl()

--- a/src/Services/MessageButton/ChatBoxDecorator.php
+++ b/src/Services/MessageButton/ChatBoxDecorator.php
@@ -37,7 +37,7 @@ class ChatBoxDecorator
 
     public function getFooterText()
     {
-        return $this->getData('chatbox_footer_text', __('Chat with us on WhatsApp for instant support!', 'wp-sms'));
+        return $this->getData('chatbox_footer_text');
     }
 
     public function getFooterLinkUrl()

--- a/tests/js/MessageButton.test.jsx
+++ b/tests/js/MessageButton.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { waitFor } from '@testing-library/react'
+import MessageButton from '@/pages/MessageButton'
+import { renderWithProviders, setupWpSmsSettings } from './testing-utils'
+
+describe('MessageButton footer preview', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <aside class="wpsms-chatbox">
+        <button class="wpsms-chatbox__button">
+          <span class="wpsms-chatbox__button-title"></span>
+        </button>
+        <div class="wpsms-chatbox__content">
+          <header class="wpsms-chatbox__header"><h2></h2></header>
+          <div class="wpsms-chatbox__container"></div>
+          <footer class="wpsms-chatbox__info">
+            <div class="wpsms-chatbox__info--text">
+              Chat with us on WhatsApp for instant support!
+            </div>
+            <div class="wpsms-chatbox__copy-right">Powered By WSMS</div>
+          </footer>
+          <span class="wpsms-chatbox__arrow"></span>
+        </div>
+      </aside>
+    `
+  })
+
+  test('shows no fallback message while preserving the footer link and branding', async () => {
+    setupWpSmsSettings({
+      settings: {
+        chatbox_message_button: '1',
+        chatbox_footer_text: '',
+        chatbox_footer_link_title: 'Help Center',
+        chatbox_footer_link_url: 'https://example.com/help',
+      },
+    })
+
+    renderWithProviders(<MessageButton />)
+
+    const footer = document.querySelector('.wpsms-chatbox__info--text')
+    await waitFor(() => {
+      expect(footer).not.toHaveTextContent('Chat with us on WhatsApp for instant support!')
+      expect(footer.querySelector('a')).toHaveTextContent('Help Center')
+      expect(footer.querySelector('a')).toHaveAttribute('href', 'https://example.com/help')
+    })
+    expect(document.querySelector('.wpsms-chatbox__copy-right')).toHaveTextContent('Powered By WSMS')
+  })
+})

--- a/tests/unit/ChatBoxDecoratorTest.php
+++ b/tests/unit/ChatBoxDecoratorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace unit;
+
+use WP_SMS\Option;
+use WP_SMS\Services\MessageButton\ChatBoxDecorator;
+use WP_UnitTestCase;
+
+class ChatBoxDecoratorTest extends WP_UnitTestCase
+{
+    public function tearDown(): void
+    {
+        Option::deleteOption('chatbox_footer_text');
+
+        parent::tearDown();
+    }
+
+    public function testFooterTextIsEmptyWhenSettingIsEmpty()
+    {
+        Option::updateOption('chatbox_footer_text', '');
+
+        $chatbox = new ChatBoxDecorator();
+
+        $this->assertFalse($chatbox->getFooterText());
+    }
+
+    public function testFooterTextReturnsConfiguredValue()
+    {
+        Option::updateOption('chatbox_footer_text', 'We typically reply within minutes');
+
+        $chatbox = new ChatBoxDecorator();
+
+        $this->assertSame('We typically reply within minutes', $chatbox->getFooterText());
+    }
+}

--- a/tests/unit/ChatBoxDecoratorTest.php
+++ b/tests/unit/ChatBoxDecoratorTest.php
@@ -32,4 +32,13 @@ class ChatBoxDecoratorTest extends WP_UnitTestCase
 
         $this->assertSame('We typically reply within minutes', $chatbox->getFooterText());
     }
+
+    public function testFooterTextPreservesConfiguredZeroValue()
+    {
+        Option::updateOption('chatbox_footer_text', '0');
+
+        $chatbox = new ChatBoxDecorator();
+
+        $this->assertSame('0', $chatbox->getFooterText());
+    }
 }


### PR DESCRIPTION
## What changed
- Removed the frontend chatbox’s hardcoded footer-message fallback.
- Updated the admin live preview so an empty Footer Message stays empty.
- Added focused PHP and Jest coverage for empty and configured footer behavior, including keeping the footer link and branding intact.

## Why
Leaving Footer Message empty should not display text the administrator did not configure.

## How to test
1. Enable the Message Button.
2. Leave Footer Message empty and configure a footer link.
3. Confirm the live preview and frontend show no fallback message while the link and Powered By line remain.
4. Enter a Footer Message and confirm it appears.

## Tests
- `WP_TESTS_PHPUNIT_POLYFILLS_PATH=/tmp/wp-sms-test-deps/vendor/yoast/phpunit-polyfills php /tmp/phpunit-9.phar --filter ChatBoxDecoratorTest tests/unit/ChatBoxDecoratorTest.php`
- `npm test -- --runInBand tests/js/MessageButton.test.jsx`

Closes #516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Footer previews now display the configured footer text without adding an automatic fallback message.
  * Empty footer settings remain empty while configured links and branding continue to display correctly.

* **Tests**
  * Added coverage for empty and configured footer text scenarios in the preview and chat footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->