### PR TITLE
Make United States discoverable in the country selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 v7.2.7 - 2026-08-08
+- **Fix:** The phone-number normalization wizard now makes the United States easy to find in the default country selector ([#522](https://github.com/wp-sms/wp-sms/issues/522)).
 - **Fix:** Translations work again on WordPress 6.7+.
 - **Fix:** A number isn't added to your subscriber list when its confirmation SMS fails ([#514](https://github.com/wp-sms/wp-sms/issues/514)).
 - **Fix:** A half-finished update no longer takes the site down.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-v7.2.7 - 2026-08-08
+Unreleased
 - **Fix:** The phone-number normalization wizard now makes the United States easy to find in the default country selector ([#522](https://github.com/wp-sms/wp-sms/issues/522)).
+
+v7.2.7 - 2026-08-08
 - **Fix:** Translations work again on WordPress 6.7+.
 - **Fix:** A number isn't added to your subscriber list when its confirmation SMS fails ([#514](https://github.com/wp-sms/wp-sms/issues/514)).
 - **Fix:** A half-finished update no longer takes the site down.

--- a/resources/react/src/components/migration/CountryStep.jsx
+++ b/resources/react/src/components/migration/CountryStep.jsx
@@ -96,6 +96,7 @@ export default function CountryStep({
           placeholder={__('Select country code...', 'wp-sms')}
           searchPlaceholder={__('Search countries...', 'wp-sms')}
           aria-label={__('Default country code', 'wp-sms')}
+          triggerClassName="wsms-bg-background wsms-text-foreground"
           disabled={loading}
         />
         <p className="wsms-text-[12px] wsms-text-muted-foreground wsms-mt-2">

--- a/resources/react/src/components/migration/CountryStep.jsx
+++ b/resources/react/src/components/migration/CountryStep.jsx
@@ -2,6 +2,7 @@ import { __, sprintf } from '@wordpress/i18n'
 import React, { useMemo } from 'react'
 import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { SearchableSelect } from '@/components/ui/searchable-select'
 import { getWpSettings } from '@/lib/utils'
 
 /**
@@ -18,7 +19,34 @@ export default function CountryStep({
   onContinue,
   onBack,
 }) {
-  const { countriesByDialCode = {} } = getWpSettings()
+  const { countries = [], countriesByDialCode = {} } = getWpSettings()
+
+  const countryOptions = useMemo(() => {
+    const options = Object.entries(countriesByDialCode).map(([dialCode, label]) => ({
+      value: dialCode,
+      label,
+    }))
+    const plusOneIndex = options.findIndex(({ value: dialCode }) => dialCode === '+1')
+
+    if (plusOneIndex === -1 || !Array.isArray(countries)) {
+      return options
+    }
+
+    const plusOneCountries = countries
+      .filter(({ dialCode }) => dialCode === '+1')
+      .sort((countryA, countryB) => Number(countryB.code === 'US') - Number(countryA.code === 'US'))
+
+    if (!plusOneCountries.some(({ code }) => code === 'US')) {
+      return options
+    }
+
+    options[plusOneIndex] = {
+      value: '+1',
+      label: `${plusOneCountries.map(({ name, code }) => `${name} (${code})`).join(' & ')} (+1)`,
+    }
+
+    return options
+  }, [countries, countriesByDialCode])
 
   const exampleLine = useMemo(() => {
     if (!value) {
@@ -60,20 +88,15 @@ export default function CountryStep({
         >
           {__('Default country code', 'wp-sms')}
         </label>
-        <select
-          id="wpsms-migration-country"
-          className="wsms-w-full wsms-border wsms-border-input wsms-rounded-md wsms-px-3 wsms-py-2 wsms-text-[13px] wsms-bg-background wsms-text-foreground"
+        <SearchableSelect
           value={value || ''}
-          onChange={(e) => onChange(e.target.value)}
+          onValueChange={onChange}
+          options={countryOptions}
+          placeholder={__('Select country code...', 'wp-sms')}
+          searchPlaceholder={__('Search countries...', 'wp-sms')}
+          aria-label={__('Default country code', 'wp-sms')}
           disabled={loading}
-        >
-          <option value="">{__('Select country code...', 'wp-sms')}</option>
-          {Object.entries(countriesByDialCode).map(([dialCode, label]) => (
-            <option key={dialCode} value={dialCode}>
-              {label}
-            </option>
-          ))}
-        </select>
+        />
         <p className="wsms-text-[12px] wsms-text-muted-foreground wsms-mt-2">
           <bdi>{exampleLine}</bdi>
         </p>

--- a/resources/react/src/components/migration/CountryStep.jsx
+++ b/resources/react/src/components/migration/CountryStep.jsx
@@ -89,6 +89,7 @@ export default function CountryStep({
           {__('Default country code', 'wp-sms')}
         </label>
         <SearchableSelect
+          id="wpsms-migration-country"
           value={value || ''}
           onValueChange={onChange}
           options={countryOptions}

--- a/resources/react/src/components/ui/searchable-select.jsx
+++ b/resources/react/src/components/ui/searchable-select.jsx
@@ -14,6 +14,7 @@ import { Input } from './input'
  * @param {Function} props.onValueChange - Callback when selection changes
  * @param {string} props.placeholder - Placeholder text when nothing selected
  * @param {string} props.searchPlaceholder - Placeholder for search input
+ * @param {string} props.id - ID for associating the trigger with a label
  * @param {string} props.className - Additional CSS classes
  * @param {boolean} props.disabled - Whether the component is disabled
  */
@@ -25,6 +26,7 @@ const SearchableSelect = React.forwardRef(
       onValueChange,
       placeholder = 'Select...',
       searchPlaceholder = 'Search...',
+      id,
       className,
       disabled = false,
       triggerClassName,
@@ -133,6 +135,7 @@ const SearchableSelect = React.forwardRef(
     return (
       <div ref={containerRef} className={cn('wsms-relative wsms-w-full', className)}>
         <Button
+          id={id}
           ref={ref}
           variant="outline"
           role="combobox"

--- a/tests/js/CountryStep.test.jsx
+++ b/tests/js/CountryStep.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import CountryStep from '@/components/migration/CountryStep'
+
+const renderCountryStep = () => {
+  const onChange = jest.fn()
+
+  window.wpSmsSettings = {
+    countries: [
+      { code: 'CA', name: 'Canada', dialCode: '+1' },
+      { code: 'US', name: 'United States (USA)', dialCode: '+1' },
+      { code: 'GB', name: 'United Kingdom (UK)', dialCode: '+44' },
+    ],
+    countriesByDialCode: {
+      '+1': 'Canada & United States (USA) (+1)',
+      '+44': 'United Kingdom (UK) (+44)',
+    },
+  }
+
+  render(
+    <CountryStep
+      value=""
+      onChange={onChange}
+      loading={false}
+      onContinue={jest.fn()}
+      onBack={jest.fn()}
+    />
+  )
+
+  fireEvent.click(screen.getByRole('combobox', { name: 'Default country code' }))
+
+  return onChange
+}
+
+describe('CountryStep', () => {
+  test.each(['United States', 'USA', 'US', '+1'])(
+    'makes the United States +1 option discoverable by searching for %s',
+    (searchTerm) => {
+      renderCountryStep()
+
+      fireEvent.change(screen.getByRole('textbox', { name: 'Search countries...' }), {
+        target: { value: searchTerm },
+      })
+
+      expect(
+        screen.getByRole('button', {
+          name: 'United States (USA) (US) & Canada (CA) (+1)',
+        })
+      ).toBeInTheDocument()
+    }
+  )
+
+  test('stores +1 when the United States option is selected', () => {
+    const onChange = renderCountryStep()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'United States (USA) (US) & Canada (CA) (+1)',
+      })
+    )
+
+    expect(onChange).toHaveBeenCalledWith('+1')
+  })
+})


### PR DESCRIPTION
## What changed
- replaced the migration wizard’s native country-code dropdown with the existing searchable selector
- shows the shared `+1` option as `United States (USA) (US) & Canada (CA) (+1)`, placing the United States first and adding ISO search terms
- keeps the stored selection as the `+1` dial code
- added focused tests for searches by United States, USA, US, and +1, plus selection behavior
- preserves the selector's foreground/background contrast after switching controls
- added a user-facing changelog entry for the country selector fix under a new Unreleased section

## Why
The merged `+1` label previously started with Canada and the native selector could not search within labels, making the United States appear unavailable.

## How to test
1. Open the phone-number normalization wizard and reach **Confirm your default country**.
2. Search for `United States`, `USA`, `US`, or `+1`.
3. Select the result and confirm the migration uses `+1`.
4. Run `pnpm exec jest --runInBand tests/js/CountryStep.test.jsx tests/js/DarkModeContrast.test.jsx`.

Closes #522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the country dropdown with a searchable selector.
  * Country options can be found by name, abbreviation, or dialing code.
  * The United States `+1` option is prioritized and easier to discover.
  * Added clearer placeholder, accessibility, and loading-state support.

* **Bug Fixes**
  * Improved selection behavior so choosing the United States correctly applies the `+1` country code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
