### PR TITLE
Allow safe links in subscription validation errors

### DIFF
--- a/resources/entries/blocks.js
+++ b/resources/entries/blocks.js
@@ -124,7 +124,7 @@ let wpSmsSubscribeForm = {
                 submitButton.prop('disabled', false);
                 processingOverlay.hide();
                 let errorMessage = (data.responseJSON && data.responseJSON.data) ? data.responseJSON.data : wpsms_ajax_object.unknown_error;
-                messageContainer.fadeIn().html('<span class="wpsms-subscribe__message wpsms-subscribe__message--error"></span>').find('span').text(errorMessage);
+                messageContainer.fadeIn().html('<span class="wpsms-subscribe__message wpsms-subscribe__message--error"></span>').find('span').html(errorMessage);
             }
         });
 

--- a/src/Controller/PublicSubscribeAjax.php
+++ b/src/Controller/PublicSubscribeAjax.php
@@ -43,9 +43,28 @@ class PublicSubscribeAjax extends AjaxControllerAbstract
         $result = SubscriberUtil::subscribe($name, $number, $group_id, $customFields);
 
         if (is_wp_error($result)) {
-            throw new Exception(esc_html($result->get_error_message()));
+            throw new Exception(self::sanitizeValidationErrorMessage($result->get_error_message()));
         }
 
         return wp_send_json_success($result);
+    }
+
+    /**
+     * Sanitize developer-provided subscription validation messages.
+     *
+     * @param string $message Validation error message.
+     *
+     * @return string
+     */
+    public static function sanitizeValidationErrorMessage($message)
+    {
+        return wp_kses($message, [
+            'a'  => [
+                'href'   => true,
+                'target' => true,
+                'rel'    => true,
+            ],
+            'br' => [],
+        ]);
     }
 }

--- a/src/Services/Subscriber/SubscriberUtil.php
+++ b/src/Services/Subscriber/SubscriberUtil.php
@@ -21,7 +21,7 @@ class SubscriberUtil
      * @param $mobile
      * @param bool $group
      * @param array $customFields
-     * @return array|string
+     * @return array|string|\WP_Error
      */
     public static function subscribe($name, $mobile, $group = false, $customFields = array())
     {

--- a/tests/unit/SubscriptionValidationErrorTest.php
+++ b/tests/unit/SubscriptionValidationErrorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace unit;
+
+use WP_SMS\Controller\PublicSubscribeAjax;
+use WP_UnitTestCase;
+
+class SubscriptionValidationErrorTest extends WP_UnitTestCase
+{
+    public function testAllowsSafeLinksAndLineBreaks()
+    {
+        $message = 'You are unsubscribed.<br><br><a href="sms:+120****8404?body=START" target="_blank" rel="noopener">Text START</a>';
+
+        $this->assertSame($message, PublicSubscribeAjax::sanitizeValidationErrorMessage($message));
+    }
+
+    public function testStripsUnsafeHtmlAndAttributes()
+    {
+        $message   = '<script>alert(1)</script><a href="javascript:alert(1)" onclick="alert(1)">Text START</a>';
+        $sanitized = PublicSubscribeAjax::sanitizeValidationErrorMessage($message);
+
+        $this->assertStringNotContainsString('<script', $sanitized);
+        $this->assertStringNotContainsString('javascript:', $sanitized);
+        $this->assertStringNotContainsString('onclick', $sanitized);
+        $this->assertStringContainsString('<a href="alert(1)">Text START</a>', $sanitized);
+    }
+
+    public function testKeepsPlainTextMessagesUnchanged()
+    {
+        $message = 'This mobile is already registered, please choose another one.';
+
+        $this->assertSame($message, PublicSubscribeAjax::sanitizeValidationErrorMessage($message));
+    }
+}


### PR DESCRIPTION
## What changed
- sanitize subscription validation errors with a narrow `wp_kses()` allowlist for `<a>` and `<br>`
- render the already-sanitized validation response as HTML in the public subscription form
- add regression coverage for `sms:` links, unsafe tags/attributes, and existing plain-text messages

## Why
Developers can return actionable guidance from `wp_sms_mobile_number_validity`, including a clickable `sms:` link, without allowing arbitrary HTML or scripts in the public form.

## How to test
```bash
WP_TESTS_PHPUNIT_POLYFILLS_PATH=/tmp/wp-sms-test-deps/vendor/yoast/phpunit-polyfills php /tmp/phpunit-9.6.phar --configuration phpunit.xml.dist tests/unit/SubscriptionValidationErrorTest.php
```

Result: `OK (3 tests, 6 assertions)`.

Manual check: return a `WP_Error` from `wp_sms_mobile_number_validity` containing `<br>` and an `<a href="sms:...">` link; submit the public subscription form and confirm the link is clickable while script tags and event-handler attributes are removed.

Closes #525


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription validation errors now display safe links and line breaks correctly.
  * Unsafe HTML and attributes are removed from error messages to improve security.
  * Plain-text validation messages remain unchanged.
  * Error messages from subscription requests are rendered consistently, making validation feedback clearer while protecting against unsafe content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->