### PR TITLE
Confirm compatibility with WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: veronalabs, mostafa.s1990, kashani
 Tags: sms notifications, otp login, woocommerce sms, 2fa authentication, bulk sms
 Requires at least: 4.1
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 7.2.7
 License: GPL-2.0+

--- a/src/Shortcode/SubscriberShortcode.php
+++ b/src/Shortcode/SubscriberShortcode.php
@@ -19,7 +19,7 @@ class SubscriberShortcode
             'title'       => __('Subscribe SMS', 'wp-sms'),
             'description' => '',
             'groups'      => '',
-            'fields'      => '',
+            'fields'      => [],
         ], $attributes);
 
         // Store raw group IDs for the hidden form field before converting to group objects

--- a/tests/unit/CompatibilityMetadataTest.php
+++ b/tests/unit/CompatibilityMetadataTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace unit;
+
+use WP_UnitTestCase;
+
+class CompatibilityMetadataTest extends WP_UnitTestCase
+{
+    public function testReadmeDeclaresWordPress71Compatibility(): void
+    {
+        $readme = file_get_contents(dirname(__DIR__, 2) . '/readme.txt');
+
+        $this->assertMatchesRegularExpression('/^Tested up to:\s*7\.1$/m', $readme);
+    }
+}

--- a/tests/unit/SubscriberShortcodeTest.php
+++ b/tests/unit/SubscriberShortcodeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace unit;
+
+use WP_SMS\Shortcode\SubscriberShortcode;
+use WP_UnitTestCase;
+
+class SubscriberShortcodeTest extends WP_UnitTestCase
+{
+    public function testShortcodeWithoutCustomFieldsRendersWithoutWarnings()
+    {
+        $shortcode = new SubscriberShortcode();
+
+        $output = $shortcode->registerSubscriberShortcodeCallback([]);
+
+        $this->assertStringContainsString('js-wpSmsSubscribeForm', $output);
+        $this->assertStringNotContainsString('js-wpSmsSubscriberCustomFields', $output);
+    }
+}


### PR DESCRIPTION
## What changed
- update the WordPress.org `Tested up to` metadata from 7.0 to 7.1
- fix the subscriber shortcode's no-custom-fields default so rendering the primary frontend form does not pass a string to `foreach()`
- add focused regression tests for the metadata declaration and warning-free default shortcode rendering

## Why
WordPress 7.1-RC3 compatibility testing exposed a PHP warning on the default subscriber form. Using an empty array for the shortcode's `fields` default matches the template's expected data type and removes the warning. With that fixed, the tested frontend and admin flows complete without PHP or JavaScript errors, so the release metadata can advertise WordPress 7.1 compatibility.

## QA / test plan
Environment: WordPress **7.1-RC3**, PHP **8.4.23**, MariaDB **11.8.6**, Chromium **145**.

Verified:
- plugin installation and activation, including creation of the WSMS database tables
- frontend subscriber shortcode form (`[wp_sms_subscriber_form]`), HTTP 200 and visible form
- WordPress dashboard, HTTP 200
- primary WSMS admin screen, HTTP 200 and mounted dashboard content
- no browser console errors or uncaught page errors on the tested flows
- no WordPress debug-log warnings, notices, deprecations, fatal errors, or uncaught exceptions after the fix
- committed frontend/build assets compile; existing Sass and translation-audit warnings remain unrelated

Focused tests:
- `phpunit --testdox tests/unit/CompatibilityMetadataTest.php` — **OK (1 test, 1 assertion)**
- `phpunit --testdox tests/unit/SubscriberShortcodeTest.php` — **OK (1 test, 2 assertions)**
- PHP lint on the changed class and new test — passed
- `git diff --check` — passed

Closes #527
