### PR TITLE
Support multiline parameters and form-encoded Custom Gateway POSTs

### DIFF
--- a/includes/gateways/class-wpsms-gateway-custom.php
+++ b/includes/gateways/class-wpsms-gateway-custom.php
@@ -20,6 +20,7 @@ class custom extends \WP_SMS\Gateway
     public $http_parameters;
     public $raw_payload;
     public $is_post_body;
+    public $post_body_format;
     public $encode_message;
     public $documentUrl = 'https://wsms.io/docs/custom-gateway/';
 
@@ -72,11 +73,22 @@ class custom extends \WP_SMS\Gateway
             'is_post_body'    => [
                 'id'        => 'gateway_is_post_body',
                 'name'      => 'Send As POST',
-                'desc'      => __('Send HTTP Parameters as a JSON POST body, or as URL query parameters.', 'wp-sms'),
+                'desc'      => __('Send HTTP Parameters as a POST body using the selected encoding, or as URL query parameters.', 'wp-sms'),
                 'type'      => 'select',
                 'options'   => [
                     'no'  => 'No',
                     'yes' => 'Yes',
+                ],
+                'className' => 'js-wpsms-show_if_gateway_body_format_equal_key_value',
+            ],
+            'post_body_format' => [
+                'id'        => 'gateway_post_body_format',
+                'name'      => esc_html__('POST Body Encoding', 'wp-sms'),
+                'desc'      => esc_html__('Choose how Key-Value parameters are encoded when Send As POST is enabled.', 'wp-sms'),
+                'type'      => 'select',
+                'options'   => [
+                    'json'            => 'application/json',
+                    'form_urlencoded' => 'application/x-www-form-urlencoded',
                 ],
                 'className' => 'js-wpsms-show_if_gateway_body_format_equal_key_value',
             ],
@@ -159,7 +171,7 @@ class custom extends \WP_SMS\Gateway
                 );
                 $httpMethod = 'POST';
             } else {
-                // Key-Value mode: parse `key:value` lines, replace placeholders, and send as query string or JSON body.
+                // Key-Value mode: parse `key:value` lines, replace placeholders, and send as query parameters or an encoded POST body.
                 $definedParams = [];
                 if ($this->http_parameters) {
                     $lines = explode("\n", $this->http_parameters);
@@ -192,8 +204,24 @@ class custom extends \WP_SMS\Gateway
                 }
 
                 if ($this->is_post_body && $this->is_post_body == 'yes') {
-                    $args['body'] = wp_json_encode($finalParams);
-                    $httpMethod   = 'POST';
+                    if ($this->post_body_format === 'form_urlencoded') {
+                        $args['body'] = http_build_query($finalParams, '', '&');
+
+                        $hasContentType = false;
+                        foreach (array_keys($args['headers']) as $headerName) {
+                            if (strcasecmp($headerName, 'Content-Type') === 0) {
+                                $hasContentType = true;
+                                break;
+                            }
+                        }
+
+                        if (!$hasContentType) {
+                            $args['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
+                        }
+                    } else {
+                        $args['body'] = wp_json_encode($finalParams);
+                    }
+                    $httpMethod = 'POST';
                 } else {
                     $params = $finalParams;
                 }

--- a/resources/react/src/components/wizard/steps/ConfigurationStep.jsx
+++ b/resources/react/src/components/wizard/steps/ConfigurationStep.jsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { Settings, Loader2, CheckCircle, XCircle, ExternalLink, AlertCircle } from 'lucide-react'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { InputField, SelectField } from '@/components/ui/form-field'
+import { InputField, SelectField, TextareaField } from '@/components/ui/form-field'
 import { Tip } from '@/components/ui/ux-helpers'
 import { settingsApi } from '@/api/settingsApi'
 import { getGatewayDisplayName as getGatewayName } from '@/lib/utils'
@@ -150,6 +150,21 @@ export default function ConfigurationStep({
                         onValueChange={(value) => handleFieldChange(field.id, value)}
                         placeholder={field.placeholder || `Select ${field.name}`}
                         options={options}
+                      />
+                    </div>
+                  )
+                }
+
+                if (field.type === 'textarea') {
+                  return (
+                    <div key={field.id} className="md:wsms-col-span-2">
+                      <TextareaField
+                        label={field.name}
+                        description={field.desc}
+                        value={fieldValue}
+                        onChange={(e) => handleFieldChange(field.id, e.target.value)}
+                        placeholder={field.placeholder || ''}
+                        rows={field.rows || 4}
                       />
                     </div>
                   )

--- a/tests/js/ConfigurationStep.test.jsx
+++ b/tests/js/ConfigurationStep.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import ConfigurationStep from '@/components/wizard/steps/ConfigurationStep'
+
+jest.mock('@/hooks/useGatewayRegistry', () => ({
+  __esModule: true,
+  default: () => ({ gateways: [] }),
+}))
+
+describe('ConfigurationStep', () => {
+  test('renders gateway textarea fields as multiline controls', () => {
+    render(
+      <ConfigurationStep
+        gatewayName="custom"
+        gatewayCapabilities={{
+          gatewayFields: {
+            http_parameters: {
+              id: 'gateway_http_parameters',
+              name: 'HTTP Parameters',
+              type: 'textarea',
+            },
+          },
+        }}
+        credentials={{ gateway_http_parameters: 'api_key:xxx\nmessage:{message}' }}
+        onCredentialChange={jest.fn()}
+      />
+    )
+
+    const field = screen.getByLabelText('HTTP Parameters')
+
+    expect(field.tagName).toBe('TEXTAREA')
+    expect(field).toHaveValue('api_key:xxx\nmessage:{message}')
+  })
+})

--- a/tests/unit/gateways/CustomGatewayTest.php
+++ b/tests/unit/gateways/CustomGatewayTest.php
@@ -78,6 +78,33 @@ class CustomGatewayTest extends WP_UnitTestCase
         $this->gateway->SendSMS();
     }
 
+    public function test_key_value_post_supports_form_urlencoded_body()
+    {
+        $this->gateway->to               = ['+31600000001'];
+        $this->gateway->is_post_body     = 'yes';
+        $this->gateway->post_body_format = 'form_urlencoded';
+        $this->gateway->http_parameters  = "to:{to}\nmessage:{message}";
+
+        $this->gateway->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'https://example.test/send',
+                [],
+                $this->callback(function ($args) {
+                    parse_str($args['body'], $decoded);
+
+                    return $decoded === [
+                        'to'      => '+31600000001',
+                        'message' => 'Hello world',
+                    ] && $args['headers']['Content-Type'] === 'application/x-www-form-urlencoded';
+                })
+            )
+            ->willReturn('ok');
+
+        $this->gateway->SendSMS();
+    }
+
     public function test_key_value_bracket_syntax_produces_json_array()
     {
         $this->gateway->is_post_body    = 'yes';


### PR DESCRIPTION
## What changed
- Render gateway fields marked as `textarea` as multiline controls in the onboarding wizard.
- Add a **POST Body Encoding** option for Custom Gateway Key-Value requests.
- Support `application/x-www-form-urlencoded` request bodies while preserving JSON as the backward-compatible default.
- Add focused React and PHP regression tests.

## Why
The onboarding wizard previously ignored the Custom Gateway field type, so HTTP parameters could not be entered one per line. Key-Value POST requests were also always JSON-encoded, preventing integrations with providers that require standard form encoding.

## How to test
- `corepack pnpm exec jest tests/js/ConfigurationStep.test.jsx --runInBand` — passes (1 test).
- `WP_TESTS_PHPUNIT_POLYFILLS_PATH=/tmp/phpunit-deps/vendor/yoast/phpunit-polyfills php /tmp/phpunit-9.phar tests/unit/gateways/CustomGatewayTest.php --filter test_key_value_post_supports_form_urlencoded_body` — passes (1 test).
- `php -l includes/gateways/class-wpsms-gateway-custom.php` — passes.
- `php -l tests/unit/gateways/CustomGatewayTest.php` — passes.

The full `CustomGatewayTest.php` file was not used as the acceptance check because six existing multi-recipient expectations fail under this sandbox's WordPress test environment; the focused regression above passes.

## Manual verification
1. Run the onboarding wizard and select Custom Gateway.
2. Confirm **HTTP Parameters** is a multiline textarea.
3. Choose Key-Value, enable **Send As POST**, and select `application/x-www-form-urlencoded` under **POST Body Encoding**.
4. Send a test request and confirm the body is form-encoded with the matching `Content-Type` header.

Closes #529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing JSON or URL-encoded formats for custom gateway POST requests.
  * Added textarea fields for entering multiline gateway credentials, with configurable placeholders and row counts.

* **Bug Fixes**
  * URL-encoded requests now apply the appropriate content type and preserve parameter values correctly.

* **Tests**
  * Added coverage for textarea credential fields and URL-encoded gateway requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->